### PR TITLE
feat: add handoff for create command

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -49,8 +49,8 @@ var infoCmd = &cobra.Command{
 			log.Panic(err)
 		}
 		fmt.Printf("----------- \n")
-	
-		reports.CommandSummary(infoSummary)
+
+		fmt.Println(reports.StyleMessage(infoSummary.String()))
 	},
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     build:
       context: ./build
     container_name: kubefirst-dev
+    environment:
+      TERM: xterm-256color
     ports:
       - "8080:8080" # ArgoCD
       - "8888:8888" # GitLab

--- a/internal/reports/command-summary.go
+++ b/internal/reports/command-summary.go
@@ -111,6 +111,19 @@ func max(a, b int) int {
 // CommandSummary receives a well-formatted buffer of bytes, and style it to the output.
 func CommandSummary(cleanSummary bytes.Buffer) {
 
+	style := getStyle()
+
+	p := tea.NewProgram(
+		Model{Content: style.Render(cleanSummary.String())},
+	)
+
+	if err := p.Start(); err != nil {
+		log.Panicf("unable to load reports screen, error is: %s", err)
+	}
+}
+
+func getStyle() lipgloss.Style {
+
 	const kubefirstBoldPurple = "#d0bae9"
 	const kubefirstLightPurple = "#3c356c"
 
@@ -122,12 +135,11 @@ func CommandSummary(cleanSummary bytes.Buffer) {
 		PaddingLeft(2).
 		PaddingRight(2).
 		Width(75)
+	return style
+}
 
-	p := tea.NewProgram(
-		Model{Content: style.Render(cleanSummary.String())},
-	)
-
-	if err := p.Start(); err != nil {
-		log.Panicf("unable to load reports screen, error is: %s", err)
-	}
+// StyleMessage receives a string and return a style string
+func StyleMessage(message string) string {
+	style := getStyle()
+	return style.Render(message)
 }

--- a/internal/reports/command-summary.go
+++ b/internal/reports/command-summary.go
@@ -124,12 +124,12 @@ func CommandSummary(cleanSummary bytes.Buffer) {
 
 func getStyle() lipgloss.Style {
 
-	const kubefirstBoldPurple = "#d0bae9"
-	const kubefirstLightPurple = "#3c356c"
+	const kubefirstBoldPurple = "#5f00af"
+	const kubefirstLightPurple = "#d0bae9"
 
 	var style = lipgloss.NewStyle().
-		Foreground(lipgloss.Color(kubefirstBoldPurple)).
-		Background(lipgloss.Color(kubefirstLightPurple)).
+		Foreground(lipgloss.Color(kubefirstLightPurple)).
+		Background(lipgloss.Color(kubefirstBoldPurple)).
 		PaddingTop(2).
 		PaddingBottom(2).
 		PaddingLeft(2).

--- a/internal/reports/command-summary_test.go
+++ b/internal/reports/command-summary_test.go
@@ -1,0 +1,20 @@
+package reports
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStyleMessage test if a regular string get transformed into a new styled string and keep its original content
+// not changed
+func TestStyleMessage(t *testing.T) {
+
+	message := "kubefirst rock!"
+	got := StyleMessage(message)
+	wanted := strings.Contains(got, message)
+
+	if wanted != true {
+		t.Error("returned string doesnt contain the content of the initial message")
+	}
+
+}

--- a/internal/reports/create.go
+++ b/internal/reports/create.go
@@ -1,0 +1,50 @@
+package reports
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+type CreateHandOff struct {
+	AwsAccountId      string
+	AwsHostedZoneName string
+	AwsRegion         string
+	ClusterName       string
+	ArgoCDUrl         string
+	ArgoCDUsername    string
+	ArgoCDPassword    string
+	VaultUrl          string
+	VaultToken        string
+}
+
+func BuildCreateHandOffReport(clusterData CreateHandOff) bytes.Buffer {
+
+	var handOffData bytes.Buffer
+	handOffData.WriteString(strings.Repeat("-", 70))
+	handOffData.WriteString(fmt.Sprintf("\nCluster %q is up and running!:\n", clusterData.ClusterName))
+	handOffData.WriteString(strings.Repeat("-", 70))
+
+	handOffData.WriteString("\n\n--- AWS ")
+	handOffData.WriteString(strings.Repeat("-", 62))
+	handOffData.WriteString(fmt.Sprintf("\n AWS Account Id: %s\n", clusterData.AwsAccountId))
+	handOffData.WriteString(fmt.Sprintf(" AWS hosted zone name: %s\n", clusterData.AwsHostedZoneName))
+	handOffData.WriteString(fmt.Sprintf(" AWS region: %s\n", clusterData.AwsRegion))
+	handOffData.WriteString(strings.Repeat("-", 70))
+
+	handOffData.WriteString("\n\n--- ArgoCD ")
+	handOffData.WriteString(strings.Repeat("-", 59))
+	handOffData.WriteString(fmt.Sprintf("\n URL: %s\n", clusterData.ArgoCDUrl))
+	handOffData.WriteString(fmt.Sprintf(" username: %s\n", clusterData.ArgoCDUsername))
+	handOffData.WriteString(fmt.Sprintf(" password: %s\n", clusterData.ArgoCDPassword))
+	handOffData.WriteString(strings.Repeat("-", 70))
+
+	handOffData.WriteString("\n\n--- Vault ")
+	handOffData.WriteString(strings.Repeat("-", 59))
+	handOffData.WriteString(fmt.Sprintf("\n URL: %s\n", clusterData.VaultUrl))
+	handOffData.WriteString(fmt.Sprintf(" token: %s\n", clusterData.VaultToken))
+	handOffData.WriteString(strings.Repeat("-", 70))
+
+	return handOffData
+
+}

--- a/internal/reports/create_test.go
+++ b/internal/reports/create_test.go
@@ -1,0 +1,29 @@
+package reports
+
+import (
+	"strings"
+	"testing"
+)
+
+// todo: test all conditions using table test table
+// TestBuildCreateHandOffReport test if the built string is consuming the required data
+func TestBuildCreateHandOffReport(t *testing.T) {
+	mockURL := "mock-url"
+	mockUsername := "mock-username"
+	mockPassword := "mock-password"
+
+	handOffData := CreateHandOff{
+		ArgoCDUrl:      mockURL,
+		ArgoCDUsername: mockUsername,
+		ArgoCDPassword: mockPassword,
+	}
+	got := BuildCreateHandOffReport(handOffData)
+
+	if !strings.Contains(got.String(), mockUsername) {
+		t.Errorf("built buffer doesn't contain %q", mockUsername)
+	}
+
+	if !strings.Contains(got.String(), mockPassword) {
+		t.Errorf("built buffer doesn't contain %q", mockPassword)
+	}
+}


### PR DESCRIPTION
- adds create handoff screen
- adds docker colors support
- decrease colors to 256 to avoid color mismtach between different terminal apps

![Screenshot 2022-07-15 at 12 42 34](https://user-images.githubusercontent.com/188671/179258570-c921a873-3bb9-417e-8894-9a0c41a1bdda.png)

notes;
1. our `~.kubefirst` is constantly been updated, this screen version won't have all the data/services.

2. at this point in time, passwords and tokens are shown in the screen, we might want to find a better solution when it gets more mature. maybe encrypting sensitive values.

Signed-off-by: João Vanzuita <joao@kubeshop.io>