### PR TITLE
Add cluster command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ go run . init --admin-email $ADMIN_EMAIL --cloud $CLOUD_PROVIDER --hosted-zone-n
 At this point, everything is ready to start provisioning the cloud services, and for that we can run:
 
 ```bash
-go run . create
+go run . cluster create
 ```
 
 ## Access ArgoCD
@@ -71,11 +71,11 @@ rm ~/.flare
 Kubefirst provides extra tooling for handling the provisioning work.
 
 | Command    | Description                                               |
-|------------|-----------------------------------------------------------|
-| argocdSync | Request ArgoCD to synchronize applications                |
-| checktools | use to check compatibility of .kubefirst/tools            |
-| clean      | removes all kubefirst resources locally for new execution |
-| create     | create a kubefirst management cluster                     |
+|:------------|:-----------------------------------------------------------|
+| argocdSync     | Request ArgoCD to synchronize applications                |
+| checktools     | use to check compatibility of .kubefirst/tools            |
+| clean          | removes all kubefirst resources locally for new execution |
+| cluster create | create a kubefirst management cluster                     |
 | destroy    | destroy the kubefirst management cluster                  |
 | info       | provides general Kubefirst setup data                     |
 | init       | initialize your local machine to execute `create`         |

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -1,0 +1,35 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// clusterCmd represents the cluster command
+var clusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Used to manage cluster level operations",
+	Long: `Cluster Level operations like create a new cluster provisioned with all kubefirst goodies.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("cluster called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(clusterCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// clusterCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// clusterCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -397,7 +397,7 @@ to quickly create a Cobra application.`,
 }
 
 func init() {
-	rootCmd.AddCommand(createCmd)
+	clusterCmd.AddCommand(createCmd)
 
 	// todo: make this an optional switch and check for it or viper
 	createCmd.Flags().Bool("destroy", false, "destroy resources")


### PR DESCRIPTION
Create a family of commands for cluster:

Changes:
`go run . create  --dry-run=true`
```bash
go run . create  --dry-run=true
Init actions: 4 expected tasks ...

LOG: 2022/07/19 16:52:27.822981 /home/developer/app/cmd/init.go:220: init started
Logging at: /home/developer/app/logs/log_1658249547.log
LOG: 2022/07/19 16:52:27.823885 /home/developer/app/pkg/helpers.go:132: Using config file: /home/developer/.kubefirst
Error: unknown command "create" for "kubefirst"
Run 'kubefirst --help' for usage.
exit status 1
```

New Command:
`go run . cluster --help`

```bash
Init actions: 4 expected tasks ...

LOG: 2022/07/19 16:51:04.343238 /home/developer/app/cmd/init.go:220: init started
Logging at: /home/developer/app/logs/log_1658249464.log
LOG: 2022/07/19 16:51:04.344766 /home/developer/app/pkg/helpers.go:132: Using config file: /home/developer/.kubefirst
Cluster Level operations like create a new cluster provisioned with all kubefirst goodies.

Usage:
  kubefirst cluster [flags]
  kubefirst cluster [command]

Available Commands:
  create      create a kubefirst management cluster

Flags:
  -h, --help   help for cluster

Use "kubefirst cluster [command] --help" for more information about a command.
```


New Create:
`go run . cluster create  --dry-run=true`
```
Regular create logs 
```



Signed-off-by: 6za <53096417+6za@users.noreply.github.com>