### PR TITLE
fix: fix docker for mac M1 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,23 @@ The setup is extremely simple, create a `.env` file in the root folder, and add 
 
 ## DNS Setup
 
+In order to install Kubefirst it's required to have a public domain. For root domains, setting the `--hosted-zone-name` 
+is enough, in case you want to use subdomains, and the domain is hosted on AWS, please follow the 
+[AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/create-subdomain-route-53/).
+
+Provisioned services on root domain will be hosted as:
+```
+argocd.example.com
+gitlab.example.com
 ...
+```
+
+Provisioned services on subdomains will be hosted as:
+```
+argocd.subdomain.example.com
+gitlab.subdomain.example.com
+...
+```
 
 ## Start the container
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 Kubefirst CLI is a cloud provisioning tool. With simple setup and few CLI calls, we spin up a full AWS cluster with full
 GitOps integration, secrets management, production and development Kubernetes environments ready to be consumed.
 
-- [Setup](#setup)
+- [Environment Variables](#environment-variables)
+- [DNS setup](#dns-setup)
 - [Start the container](#start-the-container)
 - [Initialization](#initialization)
 - [Creation](#creation)
@@ -17,16 +18,18 @@ GitOps integration, secrets management, production and development Kubernetes en
 
 ![kubefirst architecture diagram](/images/kubefirst-arch.png)
 
-## Setup
+## Environment Variables
 
 The setup is extremely simple, create a `.env` file in the root folder, and add the following variables:
 
-| Variable           | example          |
-|--------------------|------------------|
-| AWS_PROFILE        | default          |
-| CLOUD_PROVIDER=aws | aws              |
-| HOSTED_ZONE_NAME   | example.com      |
-| ADMIN_EMAIL        | john@example.com |
+| Variable    | example      |
+|-------------|--------------|
+| AWS_PROFILE | default      |
+| AWS_REGION  | eu-central-1 |
+
+## DNS Setup
+
+...
 
 ## Start the container
 
@@ -42,7 +45,7 @@ Some process requires previous initialization, for that, run:
 
 ```bash
 mkdir -p ~/.kubefirst
-go run . init --admin-email $ADMIN_EMAIL --cloud $CLOUD_PROVIDER --hosted-zone-name $HOSTED_ZONE_NAME --region $AWS_REGION
+go run . init --admin-email user@example.com --cloud aws --hosted-zone-name domain.example --region eu-central-1 --cluster-name your_cluster_name
 ```
 
 ## Creation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GitOps integration, secrets management, production and development Kubernetes en
 - [Creation](#creation)
 - [Access ArgoCD](#access-argocd)
 - [Destroy](#destroy)
-- [Available Commands]()
+- [Available Commands](#available-commands)
 
 ![kubefirst architecture diagram](/images/kubefirst-arch.png)
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ docker-compose up kubefirst-dev
 Some process requires previous initialization, for that, run:
 
 ```bash
-mkdir -p ~/.kubefirst
-go run . init --admin-email user@example.com --cloud aws --hosted-zone-name domain.example --region eu-central-1 --cluster-name your_cluster_name
+go run . init \
+--cloud aws \
+--region eu-central-1 \
+--admin-email user@example.com \
+--cluster-name your_cluster_name \
+--hosted-zone-name domain.example
 ```
 
 ## Creation
@@ -85,26 +89,23 @@ kubectl -n argocd port-forward svc/argocd-server 8080:80
 It will destroy the kubefirst management cluster, and clean up every change made in the cloud.
 
 ```bash
-
 go run . destroy
-rm -rf ~/.kubefirst
-rm ~/.flare
 ```
 
 ## Available Commands
 
 Kubefirst provides extra tooling for handling the provisioning work.
 
-| Command    | Description                                               |
-|:------------|:-----------------------------------------------------------|
+| Command        | Description                                               |
+|:---------------|:----------------------------------------------------------|
 | argocdSync     | Request ArgoCD to synchronize applications                |
 | checktools     | use to check compatibility of .kubefirst/tools            |
 | clean          | removes all kubefirst resources locally for new execution |
 | cluster create | create a kubefirst management cluster                     |
-| destroy    | destroy the kubefirst management cluster                  |
-| info       | provides general Kubefirst setup data                     |
-| init       | initialize your local machine to execute `create`         |
-| version    | print the version number for kubefirst-cli"               |
+| destroy        | destroy the kubefirst management cluster                  |
+| info           | provides general Kubefirst setup data                     |
+| init           | initialize your local machine to execute `create`         |
+| version        | print the version number for kubefirst-cli"               |
 
 ---
 ## The provisioning process

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,14 +1,10 @@
 FROM --platform=linux/amd64 golang:1.18
 
-WORKDIR /opt/kubefirst
+WORKDIR /opt/kubefirst-install
 
 RUN apt-get update && \
-    apt-get install -y unzip  curl jq vim unzip less \
+    apt-get install -y unzip curl jq vim unzip less \
      && rm -rf /var/lib/apt/lists/* 
-
-
-# enable terminal vi mode
-RUN set -o vi
 
 # Kubernetes client
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.3/bin/$(uname -s)/amd64/kubectl && \
@@ -18,23 +14,27 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.3/b
 # AWS cli
 RUN curl -LO https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
     unzip awscli-exe-linux-x86_64.zip && \
-    ./aws/install
+    ./aws/install && \
+    rm -r aws && \
+    rm awscli-exe-linux-x86_64.zip
 
 # AWS EKS cli
 RUN curl -LO https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_linux_amd64.tar.gz && \
-    tar -xvzf eksctl_linux_amd64.tar.gz -C /usr/local/bin/
+    tar -xvzf eksctl_linux_amd64.tar.gz -C /usr/local/bin/ && \
+    rm eksctl_linux_amd64.tar.gz
 
 # AWS IAM Authenticator tool
 RUN curl -LO https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
     chmod +x aws-iam-authenticator && \
     mv aws-iam-authenticator /usr/local/bin/
 
-RUN  go install github.com/spf13/cobra-cli@latest
-RUN  go install golang.org/x/tools/cmd/godoc@latest
-RUN  go install golang.org/x/lint/golint@latest
-
 
 # setup user
-# RUN useradd -ms /bin/bash developer
-# USER developer
+RUN useradd -ms /bin/bash developer
+USER developer
 WORKDIR /home/developer/kubefirst
+
+COPY --chown=developer:developer . .
+
+# download dependencies and prepare fresh installation
+RUN go mod download && go run . clean

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,5 +18,6 @@ services:
       - "8200:8200" # Vault
     volumes:
       - ./:/opt/kubefirst
+      # AWS credentials are strictly used to provision the Kubefirst in your AWS account
       - $HOME/.aws:/home/developer/.aws
     command: sh -c "./scripts/kubefirst-dev.sh"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,11 @@ services:
   kubefirst-dev:
     platform: linux/amd64
     build:
-      context: ./build
+      context: .
+      dockerfile: ./build/Dockerfile
     container_name: kubefirst-dev
+    env_file:
+      - .env
     environment:
       TERM: xterm-256color
     ports:
@@ -14,5 +17,6 @@ services:
       - "8888:8888" # GitLab
       - "8200:8200" # Vault
     volumes:
-      - ./:/home/developer/kubefirst
+      - ./:/opt/kubefirst
+      - $HOME/.aws:/home/developer/.aws
     command: sh -c "./scripts/kubefirst-dev.sh"


### PR DESCRIPTION
- allow M1 users to run Kubefirst
- README.md was also updated, and should contain the required step to start the Kubefirst installer

a quick summary:
```
1. clone this repo
2. create a .env file in the root folder containing AWS_PROFILE and AWS_REGION
3. docker compose up
4. go run . init + parameters
5. go run . cluster create
```

fix #167 


Signed-off-by: João Vanzuita <joao@kubeshop.io>