### PR TITLE
nodes_spot

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -211,13 +211,13 @@ to quickly create a Cobra application.`,
 		if gitopsTemplateGithubOrgOverride != "" {
 			log.Printf("using --gitops-template-gh-org=%s", gitopsTemplateGithubOrgOverride)
 		}
-		prepareKubefirstTemplateRepo(config, gitopsTemplateGithubOrgOverride, "gitops-template-spot", viper.GetString("version-gitops"))
+		prepareKubefirstTemplateRepo(config, gitopsTemplateGithubOrgOverride, "gitops", viper.GetString("version-gitops"))
 		log.Println("clone and detokenization of gitops-template repository complete")
 		trackers[pkg.CloneAndDetokenizeGitOpsTemplate].Tracker.Increment(int64(1))
 
 		//! tracker 7
 		log.Printf("cloning and detokenizing the metaphor-template repository")
-		prepareKubefirstTemplateRepo(config, "kubefirst", "metaphor-template", "main")
+		prepareKubefirstTemplateRepo(config, "kubefirst", "metaphor", "main")
 		log.Println("clone and detokenization of metaphor-template repository complete")
 		trackers[pkg.CloneAndDetokenizeMetaphorTemplate].Tracker.Increment(int64(1))
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -211,13 +211,13 @@ to quickly create a Cobra application.`,
 		if gitopsTemplateGithubOrgOverride != "" {
 			log.Printf("using --gitops-template-gh-org=%s", gitopsTemplateGithubOrgOverride)
 		}
-		prepareKubefirstTemplateRepo(config, gitopsTemplateGithubOrgOverride, "gitops", viper.GetString("version-gitops"))
+		prepareKubefirstTemplateRepo(config, gitopsTemplateGithubOrgOverride, "gitops-template-spot", viper.GetString("version-gitops"))
 		log.Println("clone and detokenization of gitops-template repository complete")
 		trackers[pkg.CloneAndDetokenizeGitOpsTemplate].Tracker.Increment(int64(1))
 
 		//! tracker 7
 		log.Printf("cloning and detokenizing the metaphor-template repository")
-		prepareKubefirstTemplateRepo(config, "kubefirst", "metaphor", "main")
+		prepareKubefirstTemplateRepo(config, "kubefirst", "metaphor-template", "main")
 		log.Println("clone and detokenization of metaphor-template repository complete")
 		trackers[pkg.CloneAndDetokenizeMetaphorTemplate].Tracker.Increment(int64(1))
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -123,6 +123,13 @@ to quickly create a Cobra application.`,
 		}
 		log.Println("profile:", profile)
 
+		nodes_spot, err := cmd.Flags().GetBool("aws-nodes-spot")
+		if err != nil {
+			log.Panic(err)
+		}
+		viper.Set("aws.nodes_spot", nodes_spot)
+		log.Println("aws.nodes_spot: ", nodes_spot)
+
 		// cluster name
 		clusterName, err := cmd.Flags().GetString("cluster-name")
 		if err != nil {
@@ -271,4 +278,5 @@ func init() {
 	initCmd.Flags().String("s3-suffix", "", "unique identifier for s3 buckets")
 	initCmd.Flags().String("version-gitops", "main", "version/branch used on git clone")
 	initCmd.Flags().Bool("use-telemetry", true, "installer will not send telemetry about this installation")
+	initCmd.Flags().Bool("aws-nodes-spot", false, "nodes spot on AWS EKS compute nodes")
 }

--- a/cmd/kubefirstTemplate.go
+++ b/cmd/kubefirstTemplate.go
@@ -24,7 +24,7 @@ func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName st
 		branch = "main"
 	}
 
-	repoUrl := fmt.Sprintf("https://github.com/%s/%s", githubOrg, repoName)
+	repoUrl := fmt.Sprintf("https://github.com/%s/%s-template", githubOrg, repoName)
 	directory := fmt.Sprintf("%s/%s", config.K1FolderPath, repoName)
 	log.Println("git clone", repoUrl, directory)
 	log.Println("git clone -b ", branch, repoUrl, directory)
@@ -35,12 +35,12 @@ func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName st
 		SingleBranch:  true,
 	})
 	if err != nil {
-		log.Panicf("error cloning %s repository from github %s", repoName, err)
+		log.Panicf("error cloning %s-template repository from github %s", repoName, err)
 	}
 	viper.Set(fmt.Sprintf("init.repos.%s.cloned", repoName), true)
 	viper.WriteConfig()
 
-	log.Printf("cloned %s repository to directory %s/%s", repoName, config.K1FolderPath, repoName)
+	log.Printf("cloned %s-template repository to directory %s/%s", repoName, config.K1FolderPath, repoName)
 
 	log.Printf("detokenizing %s/%s", config.K1FolderPath, repoName)
 	pkg.Detokenize(directory)

--- a/cmd/kubefirstTemplate.go
+++ b/cmd/kubefirstTemplate.go
@@ -24,7 +24,7 @@ func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName st
 		branch = "main"
 	}
 
-	repoUrl := fmt.Sprintf("https://github.com/%s/%s-template", githubOrg, repoName)
+	repoUrl := fmt.Sprintf("https://github.com/%s/%s-template-spot", githubOrg, repoName)
 	directory := fmt.Sprintf("%s/%s", config.K1FolderPath, repoName)
 	log.Println("git clone", repoUrl, directory)
 	log.Println("git clone -b ", branch, repoUrl, directory)

--- a/cmd/kubefirstTemplate.go
+++ b/cmd/kubefirstTemplate.go
@@ -24,7 +24,7 @@ func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName st
 		branch = "main"
 	}
 
-	repoUrl := fmt.Sprintf("https://github.com/%s/%s-template-spot", githubOrg, repoName)
+	repoUrl := fmt.Sprintf("https://github.com/%s/%s", githubOrg, repoName)
 	directory := fmt.Sprintf("%s/%s", config.K1FolderPath, repoName)
 	log.Println("git clone", repoUrl, directory)
 	log.Println("git clone -b ", branch, repoUrl, directory)
@@ -35,12 +35,12 @@ func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName st
 		SingleBranch:  true,
 	})
 	if err != nil {
-		log.Panicf("error cloning %s-template repository from github %s", repoName, err)
+		log.Panicf("error cloning %s repository from github %s", repoName, err)
 	}
 	viper.Set(fmt.Sprintf("init.repos.%s.cloned", repoName), true)
 	viper.WriteConfig()
 
-	log.Printf("cloned %s-template repository to directory %s/%s", repoName, config.K1FolderPath, repoName)
+	log.Printf("cloned %s repository to directory %s/%s", repoName, config.K1FolderPath, repoName)
 
 	log.Printf("detokenizing %s/%s", config.K1FolderPath, repoName)
 	pkg.Detokenize(directory)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -30,7 +30,7 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 
 		nodes_spot := viper.GetBool("aws.nodes_spot")
 		if nodes_spot {
-			envs["TF_VAR_capacity_type"] = "SPOT"
+			envs["TF_VAR_lifecycle_nodes"] = "SPOT"
 		}
 
 		log.Printf("tf env vars: ", envs)
@@ -45,7 +45,7 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 		}
 		err = pkg.ExecShellWithVars(envs, config.TerraformPath, "apply", "-auto-approve")
 		if err != nil {
-			log.Panic(fmt.Sprintf("error: terraform init failed %v", err))
+			log.Panic(fmt.Sprintf("error: terraform apply failed %v", err))
 		}
 
 		var keyOut bytes.Buffer
@@ -83,7 +83,11 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		envs["TF_VAR_aws_account_id"] = viper.GetString("aws.accountid")
 		envs["TF_VAR_aws_region"] = viper.GetString("aws.region")
 		envs["TF_VAR_hosted_zone_name"] = viper.GetString("aws.hostedzonename")
-		envs["TF_VAR_nodes_spot"] = viper.GetString("aws.nodes_spot")
+
+		nodes_spot := viper.GetBool("aws.nodes_spot")
+		if nodes_spot {
+			envs["TF_VAR_capacity_type"] = "SPOT"
+		}
 
 		err = pkg.ExecShellWithVars(envs, config.TerraformPath, "init")
 		if err != nil {

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -27,7 +27,13 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 		envs["TF_VAR_aws_account_id"] = viper.GetString("aws.accountid")
 		envs["TF_VAR_aws_region"] = viper.GetString("aws.region")
 		envs["TF_VAR_hosted_zone_name"] = viper.GetString("aws.hostedzonename")
-		envs["TF_VAR_nodes_spot"] = viper.GetString("aws.nodes_spot")
+
+		nodes_spot := viper.GetBool("aws.nodes_spot")
+		if nodes_spot {
+			envs["TF_VAR_capacity_type"] = "SPOT"
+		}
+
+		log.Printf("tf env vars: ", envs)
 
 		err := os.Chdir(directory)
 		if err != nil {

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -27,6 +27,7 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 		envs["TF_VAR_aws_account_id"] = viper.GetString("aws.accountid")
 		envs["TF_VAR_aws_region"] = viper.GetString("aws.region")
 		envs["TF_VAR_hosted_zone_name"] = viper.GetString("aws.hostedzonename")
+		envs["TF_VAR_nodes_spot"] = viper.GetString("aws.nodes_spot")
 
 		err := os.Chdir(directory)
 		if err != nil {
@@ -76,6 +77,7 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		envs["TF_VAR_aws_account_id"] = viper.GetString("aws.accountid")
 		envs["TF_VAR_aws_region"] = viper.GetString("aws.region")
 		envs["TF_VAR_hosted_zone_name"] = viper.GetString("aws.hostedzonename")
+		envs["TF_VAR_nodes_spot"] = viper.GetString("aws.nodes_spot")
 
 		err = pkg.ExecShellWithVars(envs, config.TerraformPath, "init")
 		if err != nil {


### PR DESCRIPTION
Task completed during engineering day (Kubefirst team), which allows runs spot nodes on EKS node groups.
This PR depends: https://github.com/kubefirst/gitops-template/pull/86

To enable spot instances you can use the flag: `--aws-nodes-spot` on `kubefirst init` command.