### PR TITLE
Allow templates to be version controlled by tags -  #227

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -157,12 +157,12 @@ to quickly create a Cobra application.`,
 		log.Println("version-gitops:", versionGitOps)
 
 		// version-gitops
-		templateTag, err := cmd.Flags().GetString("template-tags")
+		templateTag, err := cmd.Flags().GetString("template-tag")
 		if err != nil {
 			log.Panic(err)
 		}
 		viper.Set("template.tag", templateTag)
-		log.Println("template-tags:", templateTag)
+		log.Println("template-tag:", templateTag)
 
 		bucketRand, err := cmd.Flags().GetString("s3-suffix")
 		if err != nil {
@@ -297,7 +297,9 @@ func init() {
 	initCmd.Flags().String("s3-suffix", "", "unique identifier for s3 buckets")
 	//We should try to synch this with newer naming
 	initCmd.Flags().String("version-gitops", "", "version/branch used on git clone")
-	initCmd.Flags().String("template-tags", config.KubefirstVersion, "version/branch used on git clone")
+	initCmd.Flags().String("template-tag", config.KubefirstVersion, `fallback tag used on git clone.
+Details: if "version-gitops" is provided, branch("version-gitops") has precedence and installer will attempt to clone branch("version-gitops") first,
+if it fails, then fallback it will attempt to clone the tag provided at "template-tag" flag`)
 
 	// AWS assume role
 	initCmd.Flags().String("aws-assume-role", "", "instead of using AWS IAM user credentials, AWS AssumeRole feature generate role based credentials, more at https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -161,7 +161,7 @@ to quickly create a Cobra application.`,
 		if err != nil {
 			log.Panic(err)
 		}
-		viper.Set("templateTag", templateTag)
+		viper.Set("template.tag", templateTag)
 		log.Println("template-tags:", templateTag)
 
 		bucketRand, err := cmd.Flags().GetString("s3-suffix")
@@ -229,13 +229,13 @@ to quickly create a Cobra application.`,
 		if gitopsTemplateGithubOrgOverride != "" {
 			log.Printf("using --gitops-template-gh-org=%s", gitopsTemplateGithubOrgOverride)
 		}
-		prepareKubefirstTemplateRepo(config, gitopsTemplateGithubOrgOverride, "gitops", viper.GetString("version-gitops"), viper.GetString("templateTag"))
+		prepareKubefirstTemplateRepo(config, gitopsTemplateGithubOrgOverride, "gitops", viper.GetString("version-gitops"), viper.GetString("template.tag"))
 		log.Println("clone and detokenization of gitops-template repository complete")
 		trackers[pkg.CloneAndDetokenizeGitOpsTemplate].Tracker.Increment(int64(1))
 
 		//! tracker 7
 		log.Printf("cloning and detokenizing the metaphor-template repository")
-		prepareKubefirstTemplateRepo(config, "kubefirst", "metaphor", "", viper.GetString("templateTag"))
+		prepareKubefirstTemplateRepo(config, "kubefirst", "metaphor", "", viper.GetString("template.tag"))
 		log.Println("clone and detokenization of metaphor-template repository complete")
 		trackers[pkg.CloneAndDetokenizeMetaphorTemplate].Tracker.Increment(int64(1))
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -258,8 +258,6 @@ to quickly create a Cobra application.`,
 func init() {
 	config := configs.ReadConfig()
 
-	currentVersion := fmt.Sprintf("v%s", config.KubefirstVersion)
-
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().String("hosted-zone-name", "", "the domain to provision the kubefirst platform in")
 	err := initCmd.MarkFlagRequired("hosted-zone-name")
@@ -299,7 +297,7 @@ func init() {
 	initCmd.Flags().String("s3-suffix", "", "unique identifier for s3 buckets")
 	//We should try to synch this with newer naming
 	initCmd.Flags().String("version-gitops", "", "version/branch used on git clone")
-	initCmd.Flags().String("template-tags", currentVersion, "version/branch used on git clone")
+	initCmd.Flags().String("template-tags", config.KubefirstVersion, "version/branch used on git clone")
 
 	// AWS assume role
 	initCmd.Flags().String("aws-assume-role", "", "instead of using AWS IAM user credentials, AWS AssumeRole feature generate role based credentials, more at https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html")

--- a/cmd/kubefirstTemplate.go
+++ b/cmd/kubefirstTemplate.go
@@ -11,47 +11,20 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	gitConfig "github.com/go-git/go-git/v5/config"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/kubefirst/kubefirst/configs"
+	"github.com/kubefirst/kubefirst/internal/gitClient"
 	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/viper"
 )
 
 func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName string, branch string, tag string) {
 
-	isMainBranch := true
-	if branch == "" && tag == "" {
-		branch = "main"
-	}
-	var source plumbing.ReferenceName
-	if branch == "" && tag != "" {
-		source = plumbing.NewTagReferenceName(tag)
-	} else if branch != "" && tag == "" {
-		source = plumbing.NewBranchReferenceName(branch)
-	} else {
-		//Erroring out
-		log.Panicf("It must must be select a branch or a tag as source, both are not supported")
-	}
-
-	if branch != "main" {
-		isMainBranch = false
-	}
-
-	repoUrl := fmt.Sprintf("https://github.com/%s/%s-template", githubOrg, repoName)
 	directory := fmt.Sprintf("%s/%s", config.K1FolderPath, repoName)
-	log.Println("git clone", repoUrl, directory)
-	log.Println("git clone -b ", branch, repoUrl, directory)
-
-	repo, err := git.PlainClone(directory, false, &git.CloneOptions{
-		URL:           repoUrl,
-		ReferenceName: source,
-		SingleBranch:  true,
-	})
+	err := gitClient.CloneTemplateRepoWithFallBack(githubOrg, repoName, directory, branch, tag)
 	if err != nil {
-		log.Panicf("error cloning %s-template repository from github %s", repoName, err)
+		log.Panicf("Error cloning repo with fallback: %s", err)
 	}
-
 	viper.Set(fmt.Sprintf("init.repos.%s.cloned", repoName), true)
 	viper.WriteConfig()
 
@@ -67,6 +40,10 @@ func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName st
 	domain := viper.GetString("aws.hostedzonename")
 	log.Printf("creating git remote gitlab")
 	log.Println("git remote add gitlab at url ", fmt.Sprintf("https://gitlab.%s/kubefirst/%s.git", domain, repoName))
+	repo, err := git.PlainOpen(directory)
+	if err != nil {
+		log.Panicf("error opening the directory %s:  %s", directory, err)
+	}
 	_, err = repo.CreateRemote(&gitConfig.RemoteConfig{
 		Name: "gitlab",
 		URLs: []string{fmt.Sprintf("https://gitlab.%s/kubefirst/%s.git", domain, repoName)},
@@ -81,19 +58,6 @@ func prepareKubefirstTemplateRepo(config *configs.Config, githubOrg, repoName st
 	}
 
 	w, _ := repo.Worktree()
-	if !isMainBranch {
-		branchName := plumbing.NewBranchReferenceName("main")
-		headRef, err := repo.Head()
-		if err != nil {
-			log.Panicf("Error Setting reference: %s, %s", repoName, err)
-		}
-		ref := plumbing.NewHashReference(branchName, headRef.Hash())
-		err = repo.Storer.SetReference(ref)
-		if err != nil {
-			log.Panicf("error Storing reference: %s, %s", repoName, err)
-		}
-		err = w.Checkout(&git.CheckoutOptions{Branch: ref.Name()})
-	}
 
 	log.Println(fmt.Sprintf("committing detokenized %s content", repoName))
 	w.Add(".")

--- a/internal/gitClient/git.go
+++ b/internal/gitClient/git.go
@@ -124,7 +124,7 @@ func CloneTemplateRepoWithFallBack(githubOrg string, repoName string, directory 
 			log.Printf("error cloning %s-template repository from github %s at tag %s", repoName, err, fallbackTag)
 		} else {
 			isRepoClone = true
-			viper.Set(fmt.Sprintf("git.clone.%s.tag", repoName), branch)
+			viper.Set(fmt.Sprintf("git.clone.%s.tag", repoName), fallbackTag)
 		}
 	}
 


### PR DESCRIPTION
Add new flag to init:
```
--template-tag v1.8.x 
```

`--template-tag` will be used when cloning repos to use a frozen tag by default the same as the current cli version. 

Signed-off-by: 6za <53096417+6za@users.noreply.github.com>