### PR TITLE
feat: add kubefirst config auto push to the user state store bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ logs/
 lint_log.txt
 credentials
 kubefirst
+.idea

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
+	"github.com/kubefirst/kubefirst/internal/aws"
 	"log"
 	"net/http"
 	"os/exec"
@@ -377,6 +378,14 @@ to quickly create a Cobra application.`,
 			informUser("Vault backend configured")
 			progressPrinter.IncrementTracker("step-vault-be", 1)
 		}
+
+		// upload kubefirst config to user state S3 bucket
+		stateStoreBucket := viper.GetString("bucket.state-store.name")
+		err = aws.UploadFile(stateStoreBucket, config.KubefirstConfigFileName, config.KubefirstConfigFilePath)
+		if err != nil {
+			log.Printf("unable to upload Kubefirst cofiguration file to the S3 bucket, error is: %v", err)
+		}
+		log.Printf("Kubefirst configuration file was upload to AWS S3 at %q bucket name", stateStoreBucket)
 
 		sendCompleteInstallTelemetry(dryRun, useTelemetry)
 		time.Sleep(time.Millisecond * 100)


### PR DESCRIPTION
- at the end of the installation, upload kubefirst config file

logs output:
```
LOG: 2022/08/17 13:52:15.629188 .../kubefirst/internal/aws/aws.go:465: file uploaded to, https://s3. ... .amazonaws.com/ ... bucket name ... /.kubefirst
LOG: 2022/08/17 13:52:15.629363 .../create.go:117: Kubefirst configuration file was upload to AWS S3 at " < bucket name > " bucket name
```

fix #232 

Signed-off-by: João Vanzuita <joao@kubeshop.io>