### PR TITLE
Silent mode update

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/kubefirst/kubefirst/internal/state"
 	"log"
 	"time"
+
+	"github.com/kubefirst/kubefirst/internal/state"
 
 	"github.com/kubefirst/kubefirst/internal/flagset"
 	"github.com/kubefirst/kubefirst/internal/reports"
@@ -39,10 +40,10 @@ var createCmd = &cobra.Command{
 			}
 
 		}
-		informUser("Deploying metaphor applications", globalFlags.SilentMode)
+		informUser("Deploying metaphor applications")
 		err = deployMetaphorCmd.RunE(cmd, args)
 		if err != nil {
-			informUser("Error deploy metaphor applications", globalFlags.SilentMode)
+			informUser("Error deploy metaphor applications")
 			log.Println("Error running deployMetaphorCmd")
 			return err
 		}

--- a/cmd/createUtils.go
+++ b/cmd/createUtils.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -288,16 +287,8 @@ func waitGitlabToBeReady(dryRun bool) {
 }
 
 // Notify user in the STOUT and also logfile
-func informUser(message string, silentMode bool) {
-	// if in silent mode, send message to the screen
-	// silent mode will silent most of the messages, this function is not frequently called
-	if silentMode {
-		_, err := fmt.Fprintf(os.Stdout, message)
-		if err != nil {
-			log.Println(err)
-		}
-		return
-	}
+func informUser(message string) {
 	log.Println(message)
+	//Log message is already aware by design of the silent mode
 	progressPrinter.LogMessage(fmt.Sprintf("- %s", message))
 }

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -3,6 +3,11 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"log"
+	"os/exec"
+	"syscall"
+	"time"
+
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/flagset"
 	"github.com/kubefirst/kubefirst/internal/gitlab"
@@ -10,10 +15,6 @@ import (
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 	"github.com/kubefirst/kubefirst/internal/terraform"
 	"github.com/spf13/cobra"
-	"log"
-	"os/exec"
-	"syscall"
-	"time"
 )
 
 // destroyCmd represents the destroy command
@@ -75,7 +76,7 @@ if the registry has already been deleted.`,
 			log.Printf("Commad Execution STDERR: %s", kPortForwardErrb.String())
 
 		}
-		informUser("Open gitlab port-forward", globalFlags.SilentMode)
+		informUser("Open gitlab port-forward")
 		progressPrinter.IncrementTracker("step-prepare", 1)
 
 		if !skipDeleteRegistryApplication {
@@ -93,7 +94,7 @@ if the registry has already been deleted.`,
 				log.Printf("Commad Execution STDERR: %s", kPortForwardArgocdErrb.String())
 			}
 		}
-		informUser("Open argocd port-forward", globalFlags.SilentMode)
+		informUser("Open argocd port-forward")
 		progressPrinter.IncrementTracker("step-prepare", 1)
 
 		var kPortForwardVaultOutb, kPortForwardVaultErrb bytes.Buffer
@@ -109,14 +110,14 @@ if the registry has already been deleted.`,
 			log.Printf("Commad Execution STDOUT: %s", kPortForwardVaultOutb.String())
 			log.Printf("Commad Execution STDERR: %s", kPortForwardVaultErrb.String())
 		}
-		informUser("Open vault port-forward", globalFlags.SilentMode)
+		informUser("Open vault port-forward")
 		progressPrinter.IncrementTracker("step-prepare", 1)
 
 		log.Println("destroying gitlab terraform")
 
 		progressPrinter.AddTracker("step-destroy", "Destroy Cloud", 4)
 		progressPrinter.IncrementTracker("step-destroy", 1)
-		informUser("Destroying Gitlab", globalFlags.SilentMode)
+		informUser("Destroying Gitlab")
 		gitlab.DestroyGitlabTerraform(skipGitlabTerraform)
 		progressPrinter.IncrementTracker("step-destroy", 1)
 
@@ -124,15 +125,15 @@ if the registry has already been deleted.`,
 		log.Println("deleting registry application in argocd")
 
 		// delete argocd registry
-		informUser("Destroying Registry Application", globalFlags.SilentMode)
+		informUser("Destroying Registry Application")
 		k8s.DeleteRegistryApplication(skipDeleteRegistryApplication)
 		progressPrinter.IncrementTracker("step-destroy", 1)
 		log.Println("registry application deleted")
 		log.Println("terraform destroy base")
-		informUser("Destroying Cluster", globalFlags.SilentMode)
+		informUser("Destroying Cluster")
 		terraform.DestroyBaseTerraform(skipBaseTerraform)
 		progressPrinter.IncrementTracker("step-destroy", 1)
-		informUser("All Destroyed", globalFlags.SilentMode)
+		informUser("All Destroyed")
 
 		log.Println("terraform base destruction complete")
 		fmt.Println("End of execution destroy")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -56,11 +56,9 @@ to quickly create a Cobra application.`,
 
 		progressPrinter.GetInstance()
 		progressPrinter.SetupProgress(10, globalFlags.SilentMode)
-
-		informUser(
-			"Silent mode enabled, most of the UI prints wont be showed. Please check the logs for more details.\n",
-			globalFlags.SilentMode,
-		)
+		if globalFlags.SilentMode {
+			informUser("Silent mode enabled, most of the UI prints wont be showed. Please check the logs for more details.\n")
+		}
 
 		log.Println("github:", githubFlags.GithubHost)
 		log.Println("dry run enabled:", globalFlags.DryRun)
@@ -194,7 +192,7 @@ to quickly create a Cobra application.`,
 		progressPrinter.IncrementTracker("step-telemetry", 1)
 		time.Sleep(time.Millisecond * 100)
 
-		informUser("init is done!\n", globalFlags.SilentMode)
+		informUser("init is done!\n")
 
 		return nil
 	},

--- a/internal/flagset/installer.go
+++ b/internal/flagset/installer.go
@@ -46,7 +46,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	adminEmail, err := cmd.Flags().GetString("admin-email")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	flags.AdminEmail = adminEmail
 	log.Println("adminEmail:", adminEmail)
@@ -54,7 +54,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	clusterName, err := cmd.Flags().GetString("cluster-name")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	viper.Set("cluster-name", clusterName)
 	log.Println("cluster-name:", clusterName)
@@ -62,7 +62,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	cloud, err := cmd.Flags().GetString("cloud")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	viper.Set("cloud", cloud)
 	log.Println("cloud:", cloud)
@@ -70,7 +70,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	branchGitOps, err := cmd.Flags().GetString("gitops-branch")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	viper.Set("gitops.branch", branchGitOps)
 	log.Println("gitops.branch:", branchGitOps)
@@ -78,7 +78,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	metaphorGitOps, err := cmd.Flags().GetString("metaphor-branch")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	viper.Set("metaphor.branch", metaphorGitOps)
 	log.Println("metaphor.branch:", metaphorGitOps)
@@ -86,7 +86,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	repoGitOps, err := cmd.Flags().GetString("gitops-repo")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	viper.Set("gitops.repo", repoGitOps)
 	log.Println("gitops.repo:", repoGitOps)
@@ -94,7 +94,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	ownerGitOps, err := cmd.Flags().GetString("gitops-owner")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	viper.Set("gitops.owner", ownerGitOps)
 	log.Println("gitops.owner:", ownerGitOps)
@@ -102,7 +102,7 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 
 	templateTag, err := cmd.Flags().GetString("template-tag")
 	if err != nil {
-		return InstallerGenericFlags{}, err
+		return flags, err
 	}
 	viper.Set("template.tag", templateTag)
 	log.Println("template.tag", templateTag)


### PR DESCRIPTION
Make progressBar to support no TTY mode, send updates to STDOUT instead of rendering bars.
```
 
  ----------------------------------------------------------------------
  Info summary:
  ----------------------------------------------------------------------

  Operational System: linux
  Architecture: amd64
  Go Lang version: vgo1.17.11
  Kubefirst config file: /home/developer/.kubefirst
  Kubefirst config folder: /home/developer/.k1
  Kubectl path: /home/developer/.k1/tools/kubectl
  Terraform path: /home/developer/.k1/tools/terraform
  Kubeconfig path: /home/developer/.k1/gitops/terraform/base/kubeconfig



Init actions: 10 expected tasks ...

- Silent mode enabled, most of the UI prints wont be showed. Please check the logs for more details.

- Download dependencies [incremented: 1]
- Download dependencies [incremented: 1]
- Download dependencies [incremented: 1]
- Get Account Info [incremented: 1]
- Get DNS Info [incremented: 1]
- Test Domain Liveness [incremented: 1]
- Create Buckets [incremented: 1]
- Create SSH keys [incremented: 1]
- Clone and Detokenize (GitOps) [incremented: 1]
- Send Telemetry [incremented: 1]
- init is done!

```
Reverts change on inform user, and leverage the fact progressBar Setup already know that is noTTY mode, making it to not render and send IO to stdout without bar updates.

Make less noise the change to support noTTY mode, keeping CI/CD not that silent.


Signed-off-by: 6za <53096417+6za@users.noreply.github.com>