### PR TITLE
fix: delete s3 buckets and keep state-store bucket on deletion #309

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/aws"
 	"github.com/kubefirst/kubefirst/internal/reports"
-	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -35,13 +34,7 @@ re-create Kubefirst base files. To destroy cloud resources you need to specify a
 			return err
 		}
 		if destroyBuckets && !destroyConfirm {
-			destroyConfirm, err = pkg.AskForConfirmation("This process will delete cloud buckets and all files inside, do you really want to proceed?")
-			if err != nil {
-				return err
-			}
-			if !destroyConfirm {
-				return errors.New("destroy wasn't confirmed, not destroying buckets")
-			}
+			return errors.New("this process will fully delete cloud buckets, and we would like you to confirm the deletion providing the --destroy-confirm when calling the clean command")
 		}
 
 		err = aws.DestroyBucketsInUse(false, destroyBuckets && destroyConfirm)

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -15,50 +16,54 @@ import (
 	"github.com/spf13/viper"
 )
 
-// todo ask for user input to verify deletion?
-// todo ask for user input to verify?
-// cleanCmd removes all kubefirst resources locally for new execution.
+// cleanCmd removes all kubefirst resources created with the init command
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
-	Short: "removes all kubefirst resources locally for new execution",
+	Short: "removes all kubefirst resources created with the init command",
 	Long: `Kubefirst creates files, folders and cloud buckets during installation at your environment. This command removes and 
-re-create all Kubefirst files. To destroy cloud resources you need to specify aditional flags (--destroy-buckets)`,
-	Run: func(cmd *cobra.Command, args []string) {
+re-create Kubefirst base files. To destroy cloud resources you need to specify additional flags (--destroy-buckets)`,
+	RunE: func(cmd *cobra.Command, args []string) error {
 
 		config := configs.ReadConfig()
 
 		destroyBuckets, err := cmd.Flags().GetBool("destroy-buckets")
 		if err != nil {
-			log.Println(err)
+			return err
 		}
 		destroyConfirm, err := cmd.Flags().GetBool("destroy-confirm")
 		if err != nil {
-			log.Println(err)
+			return err
 		}
 		if destroyBuckets && !destroyConfirm {
-			destroyConfirm = pkg.AskForConfirmation("This process will delete cloud buckets and all files inside, do you really want to proceed?")
+			destroyConfirm, err = pkg.AskForConfirmation("This process will delete cloud buckets and all files inside, do you really want to proceed?")
+			if err != nil {
+				return err
+			}
 			if !destroyConfirm {
-				os.Exit(130)
+				return errors.New("destroy wasn't confirmed, not destroying buckets")
 			}
 		}
 
-		aws.DestroyBucketsInUse(false, destroyBuckets && destroyConfirm)
+		err = aws.DestroyBucketsInUse(false, destroyBuckets && destroyConfirm)
+		if err != nil {
+			return err
+		}
 
 		// command line flags
 		rmLogsFolder, err := cmd.Flags().GetBool("rm-logs")
 		if err != nil {
-			log.Panic(err)
+			return err
 		}
 
 		// delete files and folders
 		err = os.RemoveAll(config.K1FolderPath)
 		if err != nil {
-			log.Panicf("unable to delete %q folder, error is: %s", config.K1FolderPath, err)
+			return fmt.Errorf("unable to delete %q folder, error is: %s", config.K1FolderPath, err)
 		}
 
 		err = os.Remove(config.KubefirstConfigFilePath)
 		if err != nil {
-			log.Panicf("unable to delete %q file, error is: ", err)
+			return fmt.Errorf("unable to delete %q file, error is: ", err)
 		}
 
 		// remove logs folder if flag is enabled
@@ -67,13 +72,13 @@ re-create all Kubefirst files. To destroy cloud resources you need to specify ad
 			logFolderLocation = viper.GetString("log.folder.location")
 			err := os.RemoveAll(logFolderLocation)
 			if err != nil {
-				log.Panicf("unable to delete logs folder at %q", config.KubefirstLogPath)
+				return fmt.Errorf("unable to delete %q file, error is: ", err)
 			}
 		}
 
 		// re-create folder
 		if err := os.Mkdir(fmt.Sprintf("%s", config.K1FolderPath), os.ModePerm); err != nil {
-			log.Panicf("error: could not create directory %q - it must exist to continue. error is: %s", config.K1FolderPath, err)
+			return fmt.Errorf("error: could not create directory %q - it must exist to continue. error is: %s", config.K1FolderPath, err)
 		}
 
 		// re-create base
@@ -99,6 +104,8 @@ re-create all Kubefirst files. To destroy cloud resources you need to specify ad
 		cleanSummary.WriteString(fmt.Sprintf("   %q", config.KubefirstConfigFilePath))
 
 		fmt.Println(reports.StyleMessage(cleanSummary.String()))
+
+		return nil
 	},
 }
 

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -270,13 +270,14 @@ func GetDNSInfo(hostedZoneName string) string {
 
 }
 
-// listBucketsInUse list user active buckets
-func listBucketsInUse() []string {
+// ListBucketsInUse list user active buckets
+func ListBucketsInUse() []string {
 	var bucketsInUse []string
 	bucketsConfig := viper.AllKeys()
 	for _, bucketKey := range bucketsConfig {
-		match := strings.HasPrefix(bucketKey, "bucket.") && strings.HasSuffix(bucketKey, ".name")
-		if match {
+		if strings.HasPrefix(bucketKey, "bucket.") &&
+			strings.HasSuffix(bucketKey, ".name") &&
+			!strings.Contains(bucketKey, "state-store") {
 			bucketName := viper.GetString(bucketKey)
 			bucketsInUse = append(bucketsInUse, bucketName)
 		}
@@ -285,25 +286,26 @@ func listBucketsInUse() []string {
 }
 
 // DestroyBucketsInUse receives a list of user active buckets, and try to destroy them
-func DestroyBucketsInUse(dryRun bool, executeConfirmation bool) {
+func DestroyBucketsInUse(dryRun bool, executeConfirmation bool) error {
 	if dryRun {
 		log.Println("Skip: DestroyBucketsInUse - Dry-run mode")
-		return
+		return nil
 	}
 	if !executeConfirmation {
 		log.Println("Skip: DestroyBucketsInUse - Not provided confirmation")
-		return
+		return nil
 	}
 
 	log.Println("Confirmed: DestroyBucketsInUse")
 
-	for _, bucket := range listBucketsInUse() {
+	for _, bucket := range ListBucketsInUse() {
 		log.Printf("Deleting versions, objects and bucket: %s:", bucket)
 		err := DestroyBucketObjectsAndVersions(bucket, viper.GetString("aws.region"))
 		if err != nil {
-			log.Panic("Error deleting bucket/objects/version, the resources may have already been removed, please re-run without flag --destroy-buckets and check on console")
+			return errors.New("error deleting bucket/objects/version, the resources may have already been removed, please re-run without flag --destroy-buckets and check on console")
 		}
 	}
+	return nil
 }
 
 // AssumeRole receives a AWS IAM Role, and instead of using regular AWS credentials, it generates new AWS credentials

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -270,8 +270,8 @@ func GetDNSInfo(hostedZoneName string) string {
 
 }
 
-// ListBucketsInUse list user active buckets
-func ListBucketsInUse() []string {
+// listBucketsInUse list user active buckets
+func listBucketsInUse() []string {
 	var bucketsInUse []string
 	bucketsConfig := viper.AllKeys()
 	for _, bucketKey := range bucketsConfig {
@@ -298,7 +298,7 @@ func DestroyBucketsInUse(dryRun bool, executeConfirmation bool) error {
 
 	log.Println("Confirmed: DestroyBucketsInUse")
 
-	for _, bucket := range ListBucketsInUse() {
+	for _, bucket := range listBucketsInUse() {
 		log.Printf("Deleting versions, objects and bucket: %s:", bucket)
 		err := DestroyBucketObjectsAndVersions(bucket, viper.GetString("aws.region"))
 		if err != nil {

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -278,6 +278,7 @@ func ListBucketsInUse() []string {
 		if strings.HasPrefix(bucketKey, "bucket.") &&
 			strings.HasSuffix(bucketKey, ".name") &&
 			!strings.Contains(bucketKey, "state-store") {
+		
 			bucketName := viper.GetString(bucketKey)
 			bucketsInUse = append(bucketsInUse, bucketName)
 		}

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -276,9 +276,8 @@ func ListBucketsInUse() []string {
 	bucketsConfig := viper.AllKeys()
 	for _, bucketKey := range bucketsConfig {
 		if strings.HasPrefix(bucketKey, "bucket.") &&
-			strings.HasSuffix(bucketKey, ".name") &&
-			!strings.Contains(bucketKey, "state-store") {
-		
+			strings.HasSuffix(bucketKey, ".name") {
+
 			bucketName := viper.GetString(bucketKey)
 			bucketsInUse = append(bucketsInUse, bucketName)
 		}

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -202,7 +202,7 @@ func CreateFullPath(p string) (*os.File, error) {
 	return os.Create(p)
 }
 
-func AskForConfirmation(s string) bool {
+func AskForConfirmation(s string) (bool, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
@@ -210,15 +210,14 @@ func AskForConfirmation(s string) bool {
 
 		response, err := reader.ReadString('\n')
 		if err != nil {
-			log.Fatal(err)
+			return false, err
 		}
 
 		response = strings.ToLower(strings.TrimSpace(response))
 
 		if response == "y" || response == "yes" {
-			return true
-		} else if response == "n" || response == "no" {
-			return false
+			return true, nil
 		}
+		return false, nil
 	}
 }

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -200,24 +199,4 @@ func CreateFullPath(p string) (*os.File, error) {
 		return nil, err
 	}
 	return os.Create(p)
-}
-
-func AskForConfirmation(s string) (bool, error) {
-	reader := bufio.NewReader(os.Stdin)
-
-	for {
-		fmt.Printf("%s [y/n]: ", s)
-
-		response, err := reader.ReadString('\n')
-		if err != nil {
-			return false, err
-		}
-
-		response = strings.ToLower(strings.TrimSpace(response))
-
-		if response == "y" || response == "yes" {
-			return true, nil
-		}
-		return false, nil
-	}
 }


### PR DESCRIPTION
I started https://github.com/kubefirst/kubefirst/issues/309 , but I realised the `certs` bucket is not stored in the `kubefirst` file.

The backupSSL and restoreSSL uses creates a new bucket following the pattern `k1-<hosted zone name>` and doesn't store it in the `kubefirst` file.

This also remove the confirmation(user input) to delete buckets.

Signed-off-by: João Vanzuita <joao@kubeshop.io>