### PR TITLE
Re-enable #337

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -68,26 +68,26 @@ var createCmd = &cobra.Command{
 		log.Println("Kubefirst installation finished successfully")
 		informUser("Kubefirst installation finished successfully", globalFlags.SilentMode)
 		log.Println(createFlags.EnableConsole)
-		/*
-			if createFlags.EnableConsole {
-				log.Println("Starting the presentation of console and api for the handoff screen")
-				go func() {
-					errInThread := api.RunE(cmd, args)
-					if errInThread != nil {
-						log.Println(errInThread)
-					}
-				}()
-				go func() {
-					errInThread := console.RunE(cmd, args)
-					if errInThread != nil {
-						log.Println(errInThread)
-					}
-				}()
-				informUser("Kubefirst Console avilable at: http://localhost:9094", globalFlags.SilentMode)
-			} else {
-				log.Println("Skipping the presentation of console and api for the handoff screen")
-			}
-		*/
+
+		if createFlags.EnableConsole {
+			log.Println("Starting the presentation of console and api for the handoff screen")
+			go func() {
+				errInThread := api.RunE(cmd, args)
+				if errInThread != nil {
+					log.Println(errInThread)
+				}
+			}()
+			go func() {
+				errInThread := console.RunE(cmd, args)
+				if errInThread != nil {
+					log.Println(errInThread)
+				}
+			}()
+			informUser("Kubefirst Console avilable at: http://localhost:9094", globalFlags.SilentMode)
+		} else {
+			log.Println("Skipping the presentation of console and api for the handoff screen")
+		}
+
 		reports.HandoffScreen(globalFlags.DryRun, globalFlags.SilentMode)
 		time.Sleep(time.Millisecond * 2000)
 		return nil


### PR DESCRIPTION
Only #337 as it was removed from #340

By design this PR enabled Installer browser UI via a Flag(opt-in). 
It uses the handoff screen to keep the UI servers on, once the user leaves the handoff screen the is closed, the API and UI servers are shotdown. 

On silent mode, it is not tested, the idea was to just start and close the servers. But maybe we may have different ideas for it. 


How to use it: 
```bash 
./kubefirst cluster create --enable-console
```

Signed-off-by: 6za <53096417+6za@users.noreply.github.com>