### PR TITLE
fix: make softserve try 5 times before failing

### DIFF
--- a/internal/softserve/softserve.go
+++ b/internal/softserve/softserve.go
@@ -89,6 +89,7 @@ func ConfigureSoftServeAndPush(dryRun bool) {
 
 		success = true
 		log.Println("SoftServe successfully configured")
+		break
 	}
 
 	if !success {

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -3,4 +3,5 @@ package pkg
 const (
 	ArgoCDLocalBaseURL = "https://localhost:8080/api/v1"
 	JSONContentType    = "application/json"
+	SoftServerURI      = "ssh://127.0.0.1:8022/config"
 )


### PR DESCRIPTION
- make `configureSoftServe` function return errors in case of error
- `ConfigureSoftServeAndPush` is the unique caller of `configureSoftServe`, if the call to `configureSoftServe` fails, try 5 times.

closes #400 

Signed-off-by: João Vanzuita <joao@kubeshop.io>