### PR TITLE
fix: closes #414, exit gracefully when missing github token

### DIFF
--- a/cmd/githubAdd.go
+++ b/cmd/githubAdd.go
@@ -5,7 +5,6 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/kubefirst/kubefirst/internal/flagset"
@@ -20,7 +19,7 @@ var githubAddCmd = &cobra.Command{
 	Short: "Setup github for kubefirst install",
 	Long:  `Prepate github account to be used for Kubefirst installation `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("githubAddCmd called")
+
 		globalFlags, err := flagset.ProcessGlobalFlags(cmd)
 		if err != nil {
 			return err

--- a/configs/config.go
+++ b/configs/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	KubeConfigPath          string
 	HelmClientPath          string
 	TerraformPath           string
-	ConsoleVersion					string
+	ConsoleVersion          string
 
 	HostedZoneName string `env:"HOSTED_ZONE_NAME"`
 	ClusterName    string `env:"CLUSTER_NAME"`
@@ -48,6 +48,8 @@ type Config struct {
 
 	MetaphorTemplateURL string
 	GitopsTemplateURL   string
+
+	GitHubPersonalAccessToken string `env:"GITHUB_AUTH_TOKEN"`
 }
 
 func ReadConfig() *Config {

--- a/internal/flagset/github.go
+++ b/internal/flagset/github.go
@@ -1,6 +1,8 @@
 package flagset
 
 import (
+	"errors"
+	"github.com/kubefirst/kubefirst/configs"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -31,6 +33,8 @@ func DefineGithubCmdFlags(currentCommand *cobra.Command) {
 
 // ProcessGithubAddCmdFlags - Process github flags or vars
 func ProcessGithubAddCmdFlags(cmd *cobra.Command) (GithubAddCmdFlags, error) {
+
+	config := configs.ReadConfig()
 	flags := GithubAddCmdFlags{}
 	flags.GithubEnable = false
 	user, err := ReadConfigString(cmd, "github-user")
@@ -42,6 +46,14 @@ func ProcessGithubAddCmdFlags(cmd *cobra.Command) (GithubAddCmdFlags, error) {
 	if err != nil {
 		log.Println("Error Processing - github-org flag")
 		return flags, err
+	}
+
+	// if GitHub installation, and GitHub personal access token is not provided, inform that the token is required for
+	// GitHub installations
+	if len(user) > 0 && len(org) > 0 && len(config.GitHubPersonalAccessToken) == 0 {
+		errorMsg := "GITHUB_AUTH_TOKEN is required for GitHub installation"
+		log.Println(errorMsg)
+		return GithubAddCmdFlags{}, errors.New(errorMsg)
 	}
 
 	owner, err := ReadConfigString(cmd, "github-owner")


### PR DESCRIPTION
fix #414 
Signed-off-by: João Vanzuita <joao@kubeshop.io>