### PR TITLE
New command whoami

### DIFF
--- a/cmd/awsWhoami.go
+++ b/cmd/awsWhoami.go
@@ -1,0 +1,30 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kubefirst/kubefirst/internal/aws"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// awsWhoamiCmd represents the awsWhoami command
+var awsWhoamiCmd = &cobra.Command{
+	Use:   "aws-whoami",
+	Short: "A brief description of your command",
+	Long:  `TBD`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("awsWhoami called")
+		aws.GetAccountInfo()
+		fmt.Println(viper.GetString("aws.accountid"))
+		fmt.Println(viper.GetString("aws.userarn"))
+	},
+}
+
+func init() {
+	actionCmd.AddCommand(awsWhoamiCmd)
+}


### PR DESCRIPTION
To complement the assume role functionality, we are adding a new command to validate the Role and Account ID that Kubefirst is running on.