### PR TITLE
Recycle ssl metaphors apps

### DIFF
--- a/cmd/backupSsl.go
+++ b/cmd/backupSsl.go
@@ -12,18 +12,26 @@ import (
 var backupSslCmd = &cobra.Command{
 	Use:   "backupSSL",
 	Short: "Backup Secrets (cert-manager/certificates) to bucket kubefirst-<DOMAIN>",
-	Long: `This command create a backupt of secrets from certmanager certificates to bucket named kubefirst-<DOMAIN> 
-where can be used on provisioning phase with the flag --recycle-ssl`,
+	Long: `This command create a backupt of secrets from certmanager certificates to bucket named k1-<DOMAIN> 
+where are using on provisioning phase with the flag`,
 
-	Run: func(cmd *cobra.Command, args []string) {
-		_, err := ssl.GetBackupCertificates()
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		includeMetaphorApps, err := cmd.Flags().GetBool("include-metaphor")
+		if err != nil {
+			return err
+		}
+
+		_, err = ssl.GetBackupCertificates(includeMetaphorApps)
 		if err != nil {
 			log.Panic(err)
 		}
 		fmt.Println("Backup certificates finished successfully")
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(backupSslCmd)
+	backupSslCmd.Flags().Bool("include-metaphor", false, "Include Metaphor Apps in process")
 }

--- a/cmd/restoreSSL.go
+++ b/cmd/restoreSSL.go
@@ -20,7 +20,12 @@ var restoreSSLCmd = &cobra.Command{
 			return err
 		}
 
-		err = ssl.RestoreSSL(globalFlags.DryRun)
+		includeMetaphorApps, err := cmd.Flags().GetBool("include-metaphor")
+		if err != nil {
+			return err
+		}
+
+		err = ssl.RestoreSSL(globalFlags.DryRun, includeMetaphorApps)
 		if err != nil {
 			fmt.Printf("Bucket not found, missing SSL backup, assuming first installation, error is: %v", err)
 			return err
@@ -31,5 +36,6 @@ var restoreSSLCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(restoreSSLCmd)
+	restoreSSLCmd.Flags().Bool("include-metaphor", false, "Include Metaphor Apps in process")
 	flagset.DefineGlobalFlags(restoreSSLCmd)
 }


### PR DESCRIPTION
With this PR we can recycle certificates to Metaphor apps (metaphor-go, metaphor-node, metaphor-frontend).
To achieve this using the cmd the flag is: `--include-metaphor` on both commands, `backupSSL` and `restoreSSL`.
The code can be reused internally calling the function to backup or restore and inform the var `includeMetaphorApps (bool)`;

closes #442 