### PR TITLE
adjusting bot password github switch to optional

### DIFF
--- a/internal/flagset/installer.go
+++ b/internal/flagset/installer.go
@@ -141,10 +141,10 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 	log.Println("option.kubefirst.experimental", experimentalMode)
 	flags.ExperimentalMode = experimentalMode
 
-	if viper.GetBool("github.enabled") && flags.BotPassword == "" {
-		return InstallerGenericFlags{}, fmt.Errorf("must provide bot-password argument for github installations of kubefirst")
-
-	}
+	// TODO: reintroduce the next 3 lines after #511 is closed
+	//if viper.GetBool("github.enabled") && flags.BotPassword == "" {
+	//	return InstallerGenericFlags{}, fmt.Errorf("must provide bot-password argument for github installations of kubefirst")
+	//}
 
 	return experimentalModeTweaks(flags), nil
 }

--- a/internal/flagset/installer.go
+++ b/internal/flagset/installer.go
@@ -1,7 +1,6 @@
 package flagset
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/kubefirst/kubefirst/configs"


### PR DESCRIPTION
needed until #511 is closed. we can't make users provide the password and then not honor it. we'll reintroduce the check as soon as that piece is working correctly.