### PR TITLE
Test init addons

### DIFF
--- a/internal/addon/addon.go
+++ b/internal/addon/addon.go
@@ -1,11 +1,24 @@
 package addon
 
 import (
+	"log"
 	"os"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/slices"
 )
+
+func AddAddon(s string) {
+	addons := viper.GetStringSlice("addons")
+	if !slices.Contains(addons, s) {
+		log.Printf("Adding addon on kubefirst file: %s", s)
+		addons = append(addons, s)
+		viper.Set("addons", addons)
+	} else {
+		log.Printf("Addon already on kubefirst file, nothing to do: %s", s)
+	}
+}
 
 func ListAddons() {
 	addonsInstalled := viper.GetStringSlice("addons")

--- a/internal/flagset/github.go
+++ b/internal/flagset/github.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/kubefirst/kubefirst/configs"
+	"github.com/kubefirst/kubefirst/internal/addon"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -96,17 +97,11 @@ func ProcessGithubAddCmdFlags(cmd *cobra.Command) (GithubAddCmdFlags, error) {
 	viper.Set("github.owner", flags.GithubOwner)
 	viper.Set("github.enabled", flags.GithubEnable)
 
-	addons := viper.GetStringSlice("addons")
-	log.Printf("addons before define git provider: %s", addons)
-
 	if flags.GithubEnable {
-		addons = append(addons, "github")
+		addon.AddAddon("github")
 	} else {
-		addons = append(addons, "gitlab")
+		addon.AddAddon("gitlab")
 	}
-
-	viper.Set("addons", addons)
-	log.Printf("addons after define git provider: %s", addons)
 
 	return flags, nil
 

--- a/internal/flagset/init_test.go
+++ b/internal/flagset/init_test.go
@@ -280,6 +280,7 @@ func Test_Init_Addons_Gitlab(t *testing.T) {
 }
 
 func Test_Init_Addons_Github(t *testing.T) {
+	os.Setenv("GITHUB_AUTH_TOKEN", "ghp_fooBARfoo")
 	viper.Set("addons", "")
 	cmd := FakeInitAddonsTestCmd()
 	b := bytes.NewBufferString("")
@@ -299,6 +300,7 @@ func Test_Init_Addons_Github(t *testing.T) {
 }
 
 func Test_Init_Addons_Github_Kusk(t *testing.T) {
+	os.Setenv("GITHUB_AUTH_TOKEN", "ghp_fooBARfoo")
 	viper.Set("addons", "")
 	cmd := FakeInitAddonsTestCmd()
 	b := bytes.NewBufferString("")

--- a/internal/flagset/init_test.go
+++ b/internal/flagset/init_test.go
@@ -129,7 +129,7 @@ func Test_Init_aws_basic_missing_hostzone(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) == success {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }
 
@@ -149,7 +149,7 @@ func Test_Init_aws_basic_missing_profile(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) == success {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }
 
@@ -169,7 +169,7 @@ func Test_Init_aws_basic_with_profile(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) != success {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }
 
@@ -189,7 +189,7 @@ func Test_Init_aws_basic_with_arn(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) != success {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }
 
@@ -208,7 +208,7 @@ func Test_Init_aws_basic_with_profile_and_arn(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) == success {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }
 
@@ -228,7 +228,7 @@ func Test_Init_by_var_k3d(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) != success {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 	os.Unsetenv("KUBEFIRST_ADMIN_EMAIL")
 	os.Unsetenv("KUBEFIRST_CLOUD")
@@ -252,7 +252,7 @@ func Test_Init_by_var_aws_profile(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) != success {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 	os.Unsetenv("KUBEFIRST_ADMIN_EMAIL")
 	os.Unsetenv("KUBEFIRST_CLOUD")
@@ -275,7 +275,7 @@ func Test_Init_Addons_Gitlab(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) != "gitlab" {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }
 
@@ -295,7 +295,7 @@ func Test_Init_Addons_Github(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) != "github" {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }
 
@@ -315,6 +315,6 @@ func Test_Init_Addons_Github_Kusk(t *testing.T) {
 		t.Error(err)
 	}
 	if string(out) != "github,kusk" {
-		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+		t.Errorf("expected to fail validation, but got \"%s\"", string(out))
 	}
 }

--- a/internal/flagset/init_test.go
+++ b/internal/flagset/init_test.go
@@ -260,7 +260,8 @@ func Test_Init_by_var_aws_profile(t *testing.T) {
 	os.Unsetenv("KUBEFIRST_HOSTED_ZONE_NAME")
 }
 
-func Test_Init_Addons(t *testing.T) {
+func Test_Init_Addons_Gitlab(t *testing.T) {
+	viper.Set("addons", "")
 	cmd := FakeInitAddonsTestCmd()
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
@@ -273,7 +274,45 @@ func Test_Init_Addons(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if string(out) != success {
+	if string(out) != "gitlab" {
+		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+	}
+}
+
+func Test_Init_Addons_Github(t *testing.T) {
+	viper.Set("addons", "")
+	cmd := FakeInitAddonsTestCmd()
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	cmd.SetArgs([]string{"--admin-email", "user@domain.com", "--cloud", "aws", "--hosted-zone-name", "my.domain.com", "--profile", "default", "--github-user", "fake", "--github-org", "demo"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Error(err)
+	}
+	out, err := ioutil.ReadAll(b)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(out) != "github" {
+		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
+	}
+}
+
+func Test_Init_Addons_Github_Kusk(t *testing.T) {
+	viper.Set("addons", "")
+	cmd := FakeInitAddonsTestCmd()
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+	cmd.SetArgs([]string{"--admin-email", "user@domain.com", "--cloud", "aws", "--hosted-zone-name", "my.domain.com", "--profile", "default", "--github-user", "fake", "--github-org", "demo", "--addons", "kusk"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Error(err)
+	}
+	out, err := ioutil.ReadAll(b)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(out) != "github,kusk" {
 		t.Errorf("expected  to fail validation, but got \"%s\"", string(out))
 	}
 }

--- a/internal/flagset/init_test.go
+++ b/internal/flagset/init_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubefirst/kubefirst/configs"
-	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -263,21 +261,6 @@ func Test_Init_by_var_aws_profile(t *testing.T) {
 }
 
 func Test_Init_Addons(t *testing.T) {
-	// viper.SetConfigName("configTest") // name of config file (without extension)
-	// viper.SetConfigType("yaml")       // REQUIRED if the config file does not have the extension in the name
-
-	// viper.AddConfigPath(".")    // call multiple times to add many search paths
-	// err := viper.ReadInConfig() // Find and read the config file
-	// if err != nil {             // Handle errors reading the config file
-	// 	panic(fmt.Errorf("fatal error config file: %w", err))
-	// }
-	viper.New()
-	config := configs.ReadConfig()
-	viperConfigFile := config.KubefirstConfigFilePath
-	os.Remove(viperConfigFile)
-
-	pkg.SetupViper(config)
-
 	cmd := FakeInitAddonsTestCmd()
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)

--- a/internal/flagset/installer.go
+++ b/internal/flagset/installer.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/kubefirst/kubefirst/configs"
+	"github.com/kubefirst/kubefirst/internal/addon"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -143,10 +144,9 @@ func ProcessInstallerGenericFlags(cmd *cobra.Command) (InstallerGenericFlags, er
 		log.Println("Error processing addons:", err)
 		return InstallerGenericFlags{}, err
 	}
-	addons := viper.GetStringSlice("addons")
-	addons = append(addons, addonsFlag...)
-	viper.Set("addons", addons)
-	log.Println("addons", addons)
+	for _, s := range addonsFlag {
+		addon.AddAddon(s)
+	}
 
 	experimentalMode, err := ReadConfigBool(cmd, "experimental-mode")
 	if err != nil {


### PR DESCRIPTION
With this PR we made an enhancement on managing the addons list on the viper file and implement tests to cover the cases: 
`kubefirst init ...`:
- with add-ons;
- without addons;
- with GitHub or; 
- with GitLab.