### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/createUtils.go
+++ b/cmd/createUtils.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -139,7 +139,7 @@ func loopUntilPodIsReady(dryRun bool) {
 			}
 
 			defer res.Body.Close()
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				log.Println("vault is availbale but the body is not what is expected ", err)
 				continue
@@ -216,7 +216,7 @@ func initializeVaultAndAutoUnseal(dryRun bool) {
 		}
 
 		defer res.Body.Close()
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/internal/argocd/argocd.go
+++ b/internal/argocd/argocd.go
@@ -7,21 +7,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
-
-	coreV1Types "k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"github.com/spf13/viper"
-
+	"os"
 	"strings"
 	"time"
 
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/argocdModel"
 	"github.com/kubefirst/kubefirst/pkg"
+	"github.com/spf13/viper"
 	yaml2 "gopkg.in/yaml.v2"
+	coreV1Types "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 var ArgocdSecretClient coreV1Types.SecretInterface
@@ -106,7 +103,7 @@ func Sync(httpClient pkg.HTTPDoer, applicationName string, argoCDToken string) (
 		return res.StatusCode, "", nil
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return res.StatusCode, "", err
 	}
@@ -156,7 +153,7 @@ func GetArgoCDToken(username string, password string) (string, error) {
 		return "", errors.New("unable to retrieve ArgoCD token")
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
@@ -229,7 +226,7 @@ func GetArgocdAuthToken(dryRun bool) string {
 				log.Print("HTTP status NOK")
 				continue
 			}
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				log.Print("error sending POST request to get argocd auth token:", err)
 				continue
@@ -319,7 +316,7 @@ func CreateInitalArgoRepository(githubURL string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(fmt.Sprintf("%s/argocd-init-values.yaml", config.K1FolderPath), argoYaml, 0644)
+	err = os.WriteFile(fmt.Sprintf("%s/argocd-init-values.yaml", config.K1FolderPath), argoYaml, 0644)
 	if err != nil {
 		log.Printf("error: could not write argocd-init-values.yaml %s", err)
 		return err

--- a/internal/ciTools/ci.go
+++ b/internal/ciTools/ci.go
@@ -2,8 +2,8 @@ package ciTools
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/kubefirst/kubefirst/configs"
@@ -44,7 +44,7 @@ func SedBucketName(old, new string) error {
 	cfg := configs.ReadConfig()
 	providerFile := fmt.Sprintf("%s/ci/terraform/base/provider.tf", cfg.K1FolderPath)
 
-	fileData, err := ioutil.ReadFile(providerFile)
+	fileData, err := os.ReadFile(providerFile)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func SedBucketName(old, new string) error {
 	fileString = strings.ReplaceAll(fileString, old, new)
 	fileData = []byte(fileString)
 
-	err = ioutil.WriteFile(providerFile, fileData, 0o600)
+	err = os.WriteFile(providerFile, fileData, 0o600)
 	if err != nil {
 		return err
 	}

--- a/internal/flagset/common_test.go
+++ b/internal/flagset/common_test.go
@@ -3,7 +3,7 @@ package flagset
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -60,7 +60,7 @@ func Test_DefineSource_set_by_flag(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -78,7 +78,7 @@ func Test_DefineSource_set_by_var(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,7 +96,7 @@ func Test_DefineSource_notSet(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -134,7 +134,7 @@ func Test_DefineSource_set_by_flag_bool(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/flagset/init_test.go
+++ b/internal/flagset/init_test.go
@@ -3,7 +3,7 @@ package flagset
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -64,7 +64,7 @@ func Test_Init_k3d_basic(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -84,7 +84,7 @@ func Test_Init_aws_basic_missing_hostzone(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -104,7 +104,7 @@ func Test_Init_aws_basic_missing_profile(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -124,7 +124,7 @@ func Test_Init_aws_basic_with_profile(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -144,7 +144,7 @@ func Test_Init_aws_basic_with_arn(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -163,7 +163,7 @@ func Test_Init_aws_basic_with_profile_and_arn(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -183,7 +183,7 @@ func Test_Init_by_var_k3d(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}
@@ -207,7 +207,7 @@ func Test_Init_by_var_aws_profile(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/ssl/ssl.go
+++ b/internal/ssl/ssl.go
@@ -3,7 +3,6 @@ package ssl
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -182,7 +181,7 @@ func RestoreSSL(dryRun bool, includeMetaphorApps bool) error {
 		log.Print(path)
 		//clean yaml
 		//TODO filter yaml extension
-		files, err := ioutil.ReadDir(fmt.Sprintf("%s/%s", filepath.Join(config.CertsPath, path), "/"))
+		files, err := os.ReadDir(fmt.Sprintf("%s/%s", filepath.Join(config.CertsPath, path), "/"))
 		if err != nil {
 			log.Println("Error RestoreSSL:", err)
 			return fmt.Errorf("erro: %s", err)
@@ -192,7 +191,7 @@ func RestoreSSL(dryRun bool, includeMetaphorApps bool) error {
 			log.Println(f.Name())
 			pathyaml := fmt.Sprintf("%s/%s", filepath.Join(config.CertsPath, path), f.Name())
 
-			yfile, err := ioutil.ReadFile(pathyaml)
+			yfile, err := os.ReadFile(pathyaml)
 
 			if err != nil {
 				log.Println("Error RestoreSSL:", err)
@@ -222,7 +221,7 @@ func RestoreSSL(dryRun bool, includeMetaphorApps bool) error {
 				return fmt.Errorf("erro: %s", err)
 			}
 
-			err = ioutil.WriteFile(fmt.Sprintf("%s%s", pathyaml, ".clean"), dataCleaned, 0644)
+			err = os.WriteFile(fmt.Sprintf("%s%s", pathyaml, ".clean"), dataCleaned, 0644)
 
 			if err != nil {
 				log.Println("Error RestoreSSL:", err)

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/url"
@@ -75,7 +74,7 @@ func DetokenizeDirectory(path string, fi os.FileInfo, err error) error {
 	}
 
 	if matched {
-		read, err := ioutil.ReadFile(path)
+		read, err := os.ReadFile(path)
 		if err != nil {
 			log.Panic(err)
 		}
@@ -234,7 +233,7 @@ func DetokenizeDirectory(path string, fi os.FileInfo, err error) error {
 				log.Panic(err)
 			}
 		} else {
-			err = ioutil.WriteFile(path, []byte(newContents), 0)
+			err = os.WriteFile(path, []byte(newContents), 0)
 			if err != nil {
 				log.Panic(err)
 			}

--- a/pkg/keys.go
+++ b/pkg/keys.go
@@ -6,15 +6,16 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"log"
+	"os"
+	"strings"
+
 	"github.com/caarlos0/sshmarshal"
 	goGitSsh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ssh"
-	"io/ioutil"
-	"log"
-	"strings"
 )
 
 func CreateSshKeyPair() {
@@ -76,7 +77,7 @@ configs:
         %s
 `, strings.ReplaceAll(privateKey, "\n", "\n        ")))
 
-	err := ioutil.WriteFile(fmt.Sprintf("%s/argocd-init-values.yaml", config.K1FolderPath), argocdInitValuesYaml, 0644)
+	err := os.WriteFile(fmt.Sprintf("%s/argocd-init-values.yaml", config.K1FolderPath), argocdInitValuesYaml, 0644)
 	if err != nil {
 		log.Panicf("error: could not write argocd-init-values.yaml %s", err)
 	}
@@ -143,14 +144,14 @@ func generateGitHubKeys() (string, string, error) {
 // todo: function not in use, can we remove it?
 func ModConfigYaml() {
 
-	file, err := ioutil.ReadFile("./config.yaml")
+	file, err := os.ReadFile("./config.yaml")
 	if err != nil {
 		log.Println("error reading file", err)
 	}
 
 	newFile := strings.Replace(string(file), "allow-keyless: false", "allow-keyless: true", -1)
 
-	err = ioutil.WriteFile("./config.yaml", []byte(newFile), 0)
+	err = os.WriteFile("./config.yaml", []byte(newFile), 0)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir