### PR TITLE
Allow CI redeploy

### DIFF
--- a/internal/ciTools/terraform.go
+++ b/internal/ciTools/terraform.go
@@ -72,7 +72,7 @@ func DestroyCITerraform(skipCITerraform bool) {
 		if err != nil {
 			log.Printf("[WARN]: failed to terraform destroy CI, was the CI not created (check AWS)?: %s", err)
 		}
-		viper.Set("destroy.terraformdestroy.ci", true)
+		viper.Set("gitlab.ci-pushed", false)
 		viper.WriteConfig()
 	} else {
 		log.Println("skip:  destroyBaseTerraform")


### PR DESCRIPTION
Adjusting CI property on viper to allow CI redeploying after it is destroyed

Signed-off-by: Jessica Marinho <jessica@kubeshop.io>