### PR TITLE
eks graviton support

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -127,6 +127,12 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 			envs["TF_VAR_lifecycle_nodes"] = "SPOT"
 		}
 
+		nodes_graviton := viper.GetBool("aws.nodes_graviton")
+		if nodes_graviton {
+			envs["TF_VAR_ami_type"] = "AL2_ARM_64"
+			envs["TF_VAR_instance_types"] = "m6g.medium"
+		}
+
 		log.Println("tf env vars: ", envs)
 
 		err := os.Chdir(directory)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -130,7 +130,7 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 		nodes_graviton := viper.GetBool("aws.nodes_graviton")
 		if nodes_graviton {
 			envs["TF_VAR_ami_type"] = "AL2_ARM_64"
-			envs["TF_VAR_instance_type"] = "t3a.medium"
+			envs["TF_VAR_instance_type"] = "t4g.medium"
 		}
 
 		log.Println("tf env vars: ", envs)
@@ -193,7 +193,7 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		nodes_graviton := viper.GetBool("aws.nodes_graviton")
 		if nodes_graviton {
 			envs["TF_VAR_ami_type"] = "AL2_ARM_64"
-			envs["TF_VAR_instance_type"] = "t3a.medium"
+			envs["TF_VAR_instance_type"] = "t4g.medium"
 		}
 
 		err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "init")

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -190,6 +190,11 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		if nodes_spot {
 			envs["TF_VAR_capacity_type"] = "SPOT"
 		}
+		nodes_graviton := viper.GetBool("aws.nodes_graviton")
+		if nodes_graviton {
+			envs["TF_VAR_ami_type"] = "AL2_ARM_64"
+			envs["TF_VAR_instance_types"] = "m6g.medium"
+		}
 
 		err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "init")
 		if err != nil {

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -130,7 +130,7 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 		nodes_graviton := viper.GetBool("aws.nodes_graviton")
 		if nodes_graviton {
 			envs["TF_VAR_ami_type"] = "AL2_ARM_64"
-			envs["TF_VAR_instance_types"] = "m6g.medium"
+			envs["TF_VAR_instance_type"] = "t3a.medium"
 		}
 
 		log.Println("tf env vars: ", envs)
@@ -193,7 +193,7 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		nodes_graviton := viper.GetBool("aws.nodes_graviton")
 		if nodes_graviton {
 			envs["TF_VAR_ami_type"] = "AL2_ARM_64"
-			envs["TF_VAR_instance_types"] = "m6g.medium"
+			envs["TF_VAR_instance_type"] = "t3a.medium"
 		}
 
 		err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "init")

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -138,8 +138,10 @@ func DetokenizeDirectory(path string, fi os.FileInfo, err error) error {
 		githubOrg := viper.GetString("github.owner")
 		githubUser := viper.GetString("github.user")
 
+		//due to vouch proxy keep arm image in other repo than amd image we need a logic to solve this
+		//issue: https://github.com/vouch/vouch-proxy/issues/406
+		//issue on k1: https://github.com/kubefirst/kubefirst/issues/724
 		nodes_graviton := viper.GetBool("aws.nodes_graviton")
-
 		if nodes_graviton {
 			newContents = strings.Replace(newContents, "<VOUCH_DOCKER_REGISTRY>", "voucher/vouch-proxy", -1)
 			newContents = strings.Replace(newContents, "<VOUCH_DOCKER_TAG>", "latest-arm", -1)

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"errors"
 	"fmt"
-	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 	"log"
 	"math/rand"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/spf13/viper"
@@ -136,6 +137,16 @@ func DetokenizeDirectory(path string, fi os.FileInfo, err error) error {
 		githubRepoOwner := viper.GetString("github.owner")
 		githubOrg := viper.GetString("github.owner")
 		githubUser := viper.GetString("github.user")
+
+		nodes_graviton := viper.GetBool("aws.nodes_graviton")
+
+		if nodes_graviton {
+			newContents = strings.Replace(newContents, "<VOUCH_DOCKER_REGISTRY>", "voucher/vouch-proxy", -1)
+			newContents = strings.Replace(newContents, "<VOUCH_DOCKER_TAG>", "latest-arm", -1)
+		} else {
+			newContents = strings.Replace(newContents, "<VOUCH_DOCKER_REGISTRY>", "quay.io/vouch/vouch-proxy", -1)
+			newContents = strings.Replace(newContents, "<VOUCH_DOCKER_TAG>", "0.36", -1)
+		}
 
 		githubToken := os.Getenv("KUBEFIRST_GITHUB_AUTH_TOKEN")
 


### PR DESCRIPTION
Flags to allow kubefirst to create AWS EKS compute nodes with [Graviton](https://aws.amazon.com/ec2/graviton/) architecture.

This feature only supports git provider Github.

We updated the gitops-template changing apps to support the ARM chipset. PR here: 

- https://github.com/kubefirst/gitops-template/pull/179

updated Github Actions on metaphor-* to use argo bin according to the arch of runner: 

- https://github.com/kubefirst/metaphor-frontend-template/pull/21
- https://github.com/kubefirst/metaphor-go-template/pull/11
- https://github.com/kubefirst/metaphor-template/pull/17

ci-tools project/docker image used on pipelines:
- https://github.com/kubefirst/ci-tools/pull/1

docs:
- https://github.com/kubefirst/kubefirst/pull/782