### PR TITLE
fix: remove duplicated print/stdout

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -48,7 +48,6 @@ var destroyCmd = &cobra.Command{
 		}
 
 		log.Println("terraform base destruction complete")
-		fmt.Println("End of execution destroy")
 		time.Sleep(time.Millisecond * 100)
 
 		return nil


### PR DESCRIPTION
at the end of the command, the output is:
```
End of execution destroy
End of execution destroy
```

Signed-off-by: João Vanzuita <joao@kubeshop.io>