### PR TITLE
fix: Include github validation on init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -80,15 +80,17 @@ validated and configured.`,
 		}
 
 		// get GitHub data to set user and owner based on the provided token
-		githubUser, err := gitHubHandler.GetGitHubUser(gitHubAccessToken)
-		if err != nil {
-			return err
-		}
+		if providerValue == pkg.GitHubProviderName {
+			githubUser, err := gitHubHandler.GetGitHubUser(gitHubAccessToken)
+			if err != nil {
+				return err
+			}
 
-		viper.Set("github.user", githubUser)
-		err = viper.WriteConfig()
-		if err != nil {
-			return err
+			viper.Set("github.user", githubUser)
+			err = viper.WriteConfig()
+			if err != nil {
+				return err
+			}
 		}
 
 		if globalFlags.SilentMode {


### PR DESCRIPTION
Signed-off-by: Jessica Marinho <jessica@kubeshop.io>

Kubefirst init is trying to get github user even if git-provider is gitlab. To fix thus, we've included validation before calling the github API to ensure the flavor is github.