### PR TITLE
feat: implement kubernetes go client for local command port forward

### DIFF
--- a/cmd/local/connect.go
+++ b/cmd/local/connect.go
@@ -47,6 +47,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		close(minioConsoleStopChannel)
 		close(kubefirstConsoleStopChannel)
 		close(AtlantisStopChannel)
+		log.Println("leaving port-forward command, port forwards are now closed")
 	}()
 
 	err := k8s.OpenPortForwardForLocal(
@@ -76,15 +77,6 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	wg.Add(1)
 	go func() {
 		<-sigs
-		close(vaultStopChannel)
-		close(argoStopChannel)
-		close(argoCDStopChannel)
-		close(chartmuseumStopChannel)
-		close(minioStopChannel)
-		close(minioConsoleStopChannel)
-		close(kubefirstConsoleStopChannel)
-		close(AtlantisStopChannel)
-		log.Println("leaving port-forward command, port forwards are now closed")
 		wg.Done()
 	}()
 

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -146,7 +144,6 @@ func runLocal(cmd *cobra.Command, args []string) error {
 		viper.WriteConfig()
 	}
 
-	var kPortForwardArgocd *exec.Cmd
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), silentMode)
 
 	executionControl := viper.GetBool("terraform.github.apply.complete")
@@ -252,14 +249,18 @@ func runLocal(cmd *cobra.Command, args []string) error {
 		log.Println("already waited for argocd to be ready")
 	}
 
-	// establish port-forward
-	kPortForwardArgocd, err := k8s.PortForward(dryRun, "argocd", "svc/argocd-server", "8080:80")
+	// ArgoCD port-forward
+	argoCDStopChannel := make(chan struct{}, 1)
 	defer func() {
-		err = kPortForwardArgocd.Process.Signal(syscall.SIGTERM)
-		if err != nil {
-			log.Println("Error closing kPortForwardArgocd")
-		}
+		close(argoCDStopChannel)
 	}()
+	k8s.OpenPortForwardWrapper(
+		pkg.ArgoCDPodName,
+		pkg.ArgoCDNamespace,
+		pkg.ArgoCDPodPort,
+		pkg.ArgoCDPodLocalPort,
+		argoCDStopChannel,
+	)
 	pkg.InformUser(fmt.Sprintf("port-forward to argocd is available at %s", viper.GetString("argocd.local.service")), silentMode)
 
 	// argocd pods are ready, get and set credentials
@@ -281,7 +282,7 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	executionControl = viper.GetBool("argocd.registry.applied")
 	if !executionControl {
 		pkg.InformUser("applying the registry application to argocd", silentMode)
-		err = argocd.ApplyRegistryLocal(dryRun)
+		err := argocd.ApplyRegistryLocal(dryRun)
 		if err != nil {
 			log.Println("Error applying registry application to argocd")
 			return err
@@ -295,28 +296,36 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	if !executionControl {
 		pkg.InformUser("Waiting for vault to be ready", silentMode)
 		vault.WaitVaultToBeRunning(dryRun)
-		if err != nil {
-			log.Println("error waiting for vault to become running")
-			return err
-		}
 	}
-	kPortForwardVault, err := k8s.PortForward(dryRun, "vault", "svc/vault", "8200:8200")
+
+	// Vault port-forward
+	vaultStopChannel := make(chan struct{}, 1)
 	defer func() {
-		err = kPortForwardVault.Process.Signal(syscall.SIGTERM)
-		if err != nil {
-			log.Println("Error closing kPortForwardVault")
-		}
+		close(vaultStopChannel)
 	}()
+	k8s.OpenPortForwardWrapper(
+		pkg.VaultPodName,
+		pkg.VaultNamespace,
+		pkg.VaultPodPort,
+		pkg.VaultPodLocalPort,
+		vaultStopChannel,
+	)
 
 	k8s.LoopUntilPodIsReady(dryRun)
-	kPortForwardMinio, err := k8s.PortForward(dryRun, "minio", "svc/minio", "9000:9000")
-	defer func() {
-		err = kPortForwardMinio.Process.Signal(syscall.SIGTERM)
-		if err != nil {
-			log.Println("Error closing kPortForwardMinio")
-		}
-	}()
 
+	minioStopChannel := make(chan struct{}, 1)
+	defer func() {
+		close(minioStopChannel)
+	}()
+	k8s.OpenPortForwardWrapper(
+		pkg.MinioPodName,
+		pkg.MinioNamespace,
+		pkg.MinioPodPort,
+		pkg.MinioPodLocalPort,
+		minioStopChannel,
+	)
+
+	// todo: can I remove it?
 	time.Sleep(20 * time.Second)
 
 	// configure vault with terraform
@@ -373,16 +382,19 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	progressPrinter.IncrementTracker("step-apps", 1)
 
 	if !viper.GetBool("chartmuseum.host.resolved") {
-
-		//* establish port-forward
-		var kPortForwardChartMuseum *exec.Cmd
-		kPortForwardChartMuseum, err = k8s.PortForward(dryRun, "chartmuseum", "svc/chartmuseum", "8181:8080")
+		// Chartmuseum port-forward
+		chartmuseumStopChannel := make(chan struct{}, 1)
 		defer func() {
-			err = kPortForwardChartMuseum.Process.Signal(syscall.SIGTERM)
-			if err != nil {
-				log.Println("Error closing kPortForwardChartMuseum")
-			}
+			close(chartmuseumStopChannel)
 		}()
+		k8s.OpenPortForwardWrapper(
+			pkg.ChartmuseumPodName,
+			pkg.ChartmuseumNamespace,
+			pkg.ChartmuseumPodPort,
+			pkg.ChartmuseumPodLocalPort,
+			chartmuseumStopChannel,
+		)
+
 		pkg.AwaitHostNTimes("http://localhost:8181/health", 5, 5)
 		viper.Set("chartmuseum.host.resolved", true)
 		viper.WriteConfig()
@@ -391,7 +403,7 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	}
 
 	pkg.InformUser("Deploying metaphor applications", silentMode)
-	err = metaphor.DeployMetaphorGithubLocal(dryRun, githubOwner, metaphorBranch, "")
+	err := metaphor.DeployMetaphorGithubLocal(dryRun, githubOwner, metaphorBranch, "")
 	if err != nil {
 		pkg.InformUser("Error deploy metaphor applications", silentMode)
 		log.Println("Error running deployMetaphorCmd")
@@ -428,10 +440,18 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		err := k8s.OpenAtlantisPortForward()
-		if err != nil {
-			log.Println(err)
-		}
+		// Atlantis port-forward
+		atlantisStopChannel := make(chan struct{}, 1)
+		defer func() {
+			close(atlantisStopChannel)
+		}()
+		k8s.OpenPortForwardWrapper(
+			pkg.AtlantisPodName,
+			pkg.AtlantisNamespace,
+			pkg.AtlantisPodPort,
+			pkg.AtlantisPodLocalPort,
+			atlantisStopChannel,
+		)
 
 		gitHubClient := githubWrapper.New()
 		err = gitHubClient.CreatePR(branchName)

--- a/internal/k8s/kubernetes.go
+++ b/internal/k8s/kubernetes.go
@@ -184,6 +184,7 @@ func GetClientSet(dryRun bool) (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
+// deprecated
 // PortForward - opens port-forward to services
 func PortForward(dryRun bool, namespace string, filter string, ports string) (*exec.Cmd, error) {
 	if dryRun {

--- a/internal/k8s/portForward.go
+++ b/internal/k8s/portForward.go
@@ -118,6 +118,8 @@ func OpenPortForwardForCloudConConsole() error {
 }
 
 // deprecated
+// OpenPortForwardForKubeConConsole was deprecated by OpenPortForwardForLocal, that handles port forwards using k8s
+// go client.
 func OpenPortForwardForKubeConConsole() error {
 
 	var wg sync.WaitGroup

--- a/internal/k8s/portForward.go
+++ b/internal/k8s/portForward.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/kubefirst/kubefirst/configs"
-	"github.com/kubefirst/kubefirst/pkg"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 	"log"
@@ -38,74 +35,6 @@ type PortForwardAPodRequest struct {
 	StopCh <-chan struct{}
 	// ReadyCh communicates when the tunnel is ready to receive traffic
 	ReadyCh chan struct{}
-}
-
-// OpenPortForwardWrapper wrapper for PortForwardPod function. This functions make it easier to open and close port
-// forward request. By providing the function parameters, the function will manage to create the port forward. The
-// parameter for the stopChannel controls when the port forward must be closed.
-//
-// Example:
-//
-//	vaultStopChannel := make(chan struct{}, 1)
-//	go func() {
-//		OpenPortForwardWrapper(
-//			pkg.VaultPodName,
-//			pkg.VaultNamespace,
-//			pkg.VaultPodPort,
-//			pkg.VaultPodLocalPort,
-//			vaultStopChannel)
-//		wg.Done()
-//	}()
-func OpenPortForwardWrapper(podName string, namespace string, podPort int, podLocalPort int, stopChannel chan struct{}) {
-
-	config1 := configs.ReadConfig()
-	kubeconfig := config1.KubeConfigPath
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		log.Println(err)
-	}
-
-	// readyCh communicate when the port forward is ready to get traffic
-	readyCh := make(chan struct{})
-
-	// todo: constants for podName, PodPort and localPort, namespace
-	portForwardRequest := PortForwardAPodRequest{
-		RestConfig: cfg,
-		Pod: v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      podName,
-				Namespace: namespace,
-			},
-		},
-		PodPort:   podPort,
-		LocalPort: podLocalPort,
-		StopCh:    stopChannel,
-		ReadyCh:   readyCh,
-	}
-
-	clientset, err := GetClientSet(false)
-
-	go func() {
-		err = PortForwardPod(clientset, portForwardRequest)
-		if err != nil {
-			log.Println(err)
-		}
-	}()
-
-	select {
-	case <-stopChannel:
-		log.Println("leaving...")
-		close(stopChannel)
-		close(readyCh)
-		break
-	case <-readyCh:
-		log.Println("port forwarding is ready to get traffic")
-	}
-
-	log.Printf("Pod %q at namespace %q has port forward accepting connections at port %d\n", podName, namespace, podLocalPort)
-	//<-stopChannel
-
-	return
 }
 
 // PortForwardPod receives a PortForwardAPodRequest, and enable port forward for the specified resource. If the provided
@@ -167,78 +96,6 @@ func PortForwardPod(clientset *kubernetes.Clientset, req PortForwardAPodRequest)
 
 	return nil
 
-}
-
-// OpenPortForwardForLocal is a wrapper function to instantiate the necessary resources for Kubefirst
-// console. OpenPortForwardForLocal receives channels as arguments, when this channels are closed, the
-// port forwards are also closed.
-//
-// Every port forward that is open, is open in a Go routine, the function exists when all the (wg.Add(x)) x Go
-// routines are done.
-func OpenPortForwardForLocal(
-	vaultStopChannel chan struct{},
-	argoStopChannel chan struct{},
-	argoCDStopChannel chan struct{},
-	chartmuseumStopChannel chan struct{},
-	minioStopChannel chan struct{},
-	minioConsoleStopChannel chan struct{},
-	kubefirstConsoleStopChannel chan struct{},
-	AtlantisStopChannel chan struct{},
-) error {
-
-	var wg sync.WaitGroup
-	wg.Add(8)
-
-	// Vault
-	go func() {
-		OpenPortForwardWrapper(pkg.VaultPodName, pkg.VaultNamespace, pkg.VaultPodPort, pkg.VaultPodLocalPort, vaultStopChannel)
-		wg.Done()
-	}()
-
-	// Argo
-	go func() {
-		OpenPortForwardWrapper(pkg.ArgoPodName, pkg.ArgoNamespace, pkg.ArgoPodPort, pkg.ArgoPodLocalPort, argoStopChannel)
-		wg.Done()
-	}()
-
-	// ArgoCD
-	go func() {
-		OpenPortForwardWrapper(pkg.ArgoCDPodName, pkg.ArgoCDNamespace, pkg.ArgoCDPodPort, pkg.ArgoCDPodLocalPort, argoCDStopChannel)
-		wg.Done()
-	}()
-
-	// chartmuseum
-	go func() {
-		OpenPortForwardWrapper(pkg.ChartmuseumPodName, pkg.ChartmuseumNamespace, pkg.ChartmuseumPodPort, pkg.ChartmuseumPodLocalPort, chartmuseumStopChannel)
-		wg.Done()
-	}()
-
-	// Minio
-	go func() {
-		OpenPortForwardWrapper(pkg.MinioPodName, pkg.MinioNamespace, pkg.MinioPodPort, pkg.MinioPodLocalPort, minioStopChannel)
-		wg.Done()
-	}()
-
-	// Minio Console
-	go func() {
-		OpenPortForwardWrapper(pkg.MinioConsolePodName, pkg.MinioConsoleNamespace, pkg.MinioConsolePodPort, pkg.MinioConsolePodLocalPort, minioConsoleStopChannel)
-		wg.Done()
-	}()
-
-	// Kubefirst console
-	go func() {
-		OpenPortForwardWrapper(pkg.KubefirstConsolePodName, pkg.KubefirstConsoleNamespace, pkg.KubefirstConsolePodPort, pkg.KubefirstConsolePodLocalPort, kubefirstConsoleStopChannel)
-		wg.Done()
-	}()
-
-	// Atlantis
-	go func() {
-		OpenPortForwardWrapper(pkg.AtlantisPodName, pkg.AtlantisNamespace, pkg.AtlantisPodPort, pkg.AtlantisPodLocalPort, AtlantisStopChannel)
-		wg.Done()
-	}()
-
-	wg.Wait()
-	return nil
 }
 
 // todo: this is temporary

--- a/internal/k8s/wrappers.go
+++ b/internal/k8s/wrappers.go
@@ -1,0 +1,151 @@
+package k8s
+
+import (
+	"github.com/kubefirst/kubefirst/configs"
+	"github.com/kubefirst/kubefirst/pkg"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"log"
+	"sync"
+)
+
+// OpenPortForwardForLocal is a wrapper function to instantiate the necessary resources for Kubefirst
+// console. OpenPortForwardForLocal receives channels as arguments, when this channels are closed, the
+// port forwards are also closed.
+//
+// Every port forward that is open, is open in a Go routine, the function exists when all the (wg.Add(x)) x Go
+// routines are done.
+func OpenPortForwardForLocal(
+	vaultStopChannel chan struct{},
+	argoStopChannel chan struct{},
+	argoCDStopChannel chan struct{},
+	chartmuseumStopChannel chan struct{},
+	minioStopChannel chan struct{},
+	minioConsoleStopChannel chan struct{},
+	kubefirstConsoleStopChannel chan struct{},
+	AtlantisStopChannel chan struct{},
+) error {
+
+	var wg sync.WaitGroup
+	wg.Add(8)
+
+	// Vault
+	go func() {
+		OpenPortForwardWrapper(pkg.VaultPodName, pkg.VaultNamespace, pkg.VaultPodPort, pkg.VaultPodLocalPort, vaultStopChannel)
+		wg.Done()
+	}()
+
+	// Argo
+	go func() {
+		OpenPortForwardWrapper(pkg.ArgoPodName, pkg.ArgoNamespace, pkg.ArgoPodPort, pkg.ArgoPodLocalPort, argoStopChannel)
+		wg.Done()
+	}()
+
+	// ArgoCD
+	go func() {
+		OpenPortForwardWrapper(pkg.ArgoCDPodName, pkg.ArgoCDNamespace, pkg.ArgoCDPodPort, pkg.ArgoCDPodLocalPort, argoCDStopChannel)
+		wg.Done()
+	}()
+
+	// chartmuseum
+	go func() {
+		OpenPortForwardWrapper(pkg.ChartmuseumPodName, pkg.ChartmuseumNamespace, pkg.ChartmuseumPodPort, pkg.ChartmuseumPodLocalPort, chartmuseumStopChannel)
+		wg.Done()
+	}()
+
+	// Minio
+	go func() {
+		OpenPortForwardWrapper(pkg.MinioPodName, pkg.MinioNamespace, pkg.MinioPodPort, pkg.MinioPodLocalPort, minioStopChannel)
+		wg.Done()
+	}()
+
+	// Minio Console
+	go func() {
+		OpenPortForwardWrapper(pkg.MinioConsolePodName, pkg.MinioConsoleNamespace, pkg.MinioConsolePodPort, pkg.MinioConsolePodLocalPort, minioConsoleStopChannel)
+		wg.Done()
+	}()
+
+	// Kubefirst console
+	go func() {
+		OpenPortForwardWrapper(pkg.KubefirstConsolePodName, pkg.KubefirstConsoleNamespace, pkg.KubefirstConsolePodPort, pkg.KubefirstConsolePodLocalPort, kubefirstConsoleStopChannel)
+		wg.Done()
+	}()
+
+	// Atlantis
+	go func() {
+		OpenPortForwardWrapper(pkg.AtlantisPodName, pkg.AtlantisNamespace, pkg.AtlantisPodPort, pkg.AtlantisPodLocalPort, AtlantisStopChannel)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	return nil
+}
+
+// OpenPortForwardWrapper wrapper for PortForwardPod function. This functions make it easier to open and close port
+// forward request. By providing the function parameters, the function will manage to create the port forward. The
+// parameter for the stopChannel controls when the port forward must be closed.
+//
+// Example:
+//
+//	vaultStopChannel := make(chan struct{}, 1)
+//	go func() {
+//		OpenPortForwardWrapper(
+//			pkg.VaultPodName,
+//			pkg.VaultNamespace,
+//			pkg.VaultPodPort,
+//			pkg.VaultPodLocalPort,
+//			vaultStopChannel)
+//		wg.Done()
+//	}()
+func OpenPortForwardWrapper(podName string, namespace string, podPort int, podLocalPort int, stopChannel chan struct{}) {
+
+	config1 := configs.ReadConfig()
+	kubeconfig := config1.KubeConfigPath
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		log.Println(err)
+	}
+
+	// readyCh communicate when the port forward is ready to get traffic
+	readyCh := make(chan struct{})
+
+	// todo: constants for podName, PodPort and localPort, namespace
+	portForwardRequest := PortForwardAPodRequest{
+		RestConfig: cfg,
+		Pod: v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: namespace,
+			},
+		},
+		PodPort:   podPort,
+		LocalPort: podLocalPort,
+		StopCh:    stopChannel,
+		ReadyCh:   readyCh,
+	}
+
+	clientset, err := GetClientSet(false)
+
+	go func() {
+		err = PortForwardPod(clientset, portForwardRequest)
+		if err != nil {
+			log.Println(err)
+		}
+	}()
+
+	select {
+	case <-stopChannel:
+		log.Println("leaving...")
+		close(stopChannel)
+		close(readyCh)
+		break
+	case <-readyCh:
+		log.Println("port forwarding is ready to get traffic")
+	}
+
+	log.Printf("Pod %q at namespace %q has port-forward accepting local connections at port %d\n", podName, namespace, podLocalPort)
+	//<-stopChannel
+
+	return
+}


### PR DESCRIPTION
This PR:

- implements port forward for the local command using the k8s go client instead of the shell OS call

Signed-off-by: João Vanzuita <joao@kubeshop.io>