### PR TITLE
Feat introduce log levels fork

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
 
@@ -85,7 +85,7 @@ re-create Kubefirst base files. To destroy cloud resources you need to specify a
 		}
 
 		// re-create base
-		log.Printf("%q config file and %q folder were deleted and re-created", config.KubefirstConfigFilePath, config.K1FolderPath)
+		log.Info().Msgf("%q config file and %q folder were deleted and re-created", config.KubefirstConfigFilePath, config.K1FolderPath)
 
 		var cleanSummary bytes.Buffer
 		cleanSummary.WriteString(strings.Repeat("-", 70))

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
 	"runtime"
 	"strings"
 
@@ -44,11 +44,11 @@ var infoCmd = &cobra.Command{
 
 		err := configs.CheckKubefirstConfigFile(config)
 		if err != nil {
-			log.Println("Config file check:", err)
+			log.Error().Err(err).Msg("config file check")
 		}
 		err = configs.CheckKubefirstDir(config)
 		if err != nil {
-			log.Println("Installer dir check:", err)
+			log.Error().Err(err).Msg("installer dir check")
 		}
 		fmt.Printf("----------- \n")
 

--- a/cmd/local/connect.go
+++ b/cmd/local/connect.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/kubefirst/kubefirst/internal/reports"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -25,7 +25,7 @@ func NewCommandConnect() *cobra.Command {
 }
 
 func runConnect(cmd *cobra.Command, args []string) error {
-	log.Println("opening Port Forward for console...")
+	log.Info().Msg("opening Port Forward for console...")
 
 	// every port forward has its own closing control. when a channel is closed, the port forward is close.
 	vaultStopChannel := make(chan struct{}, 1)
@@ -53,7 +53,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		close(MetaphorFrontendDevelopmentStopChannel)
 		close(MetaphorGoDevelopmentStopChannel)
 		close(MetaphorDevelopmentStopChannel)
-		log.Println("leaving port-forward command, port forwards are now closed")
+		log.Info().Msg("leaving port-forward command, port forwards are now closed")
 	}()
 
 	err := k8s.OpenPortForwardForLocal(
@@ -76,8 +76,8 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	// style UI with local URLs
 	fmt.Println(reports.StyleMessage(reports.LocalConnectSummary()))
 
-	log.Println("Kubefirst port forward done")
-	log.Println("hanging port forwards until ctrl+c is called")
+	log.Info().Msg("Kubefirst port forward done")
+	log.Info().Msg("hanging port forwards until ctrl+c is called")
 
 	// managing termination signal from the terminal
 	sigs := make(chan os.Signal, 1)

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -36,6 +36,7 @@ var (
 	metaphorBranch string
 	adminEmail     string
 	templateTag    string
+	logLevel       string
 )
 
 func NewCommand() *cobra.Command {
@@ -61,6 +62,12 @@ func NewCommand() *cobra.Command {
 	localCmd.Flags().StringVar(&gitOpsRepo, "gitops-repo", "gitops", "")
 	localCmd.Flags().StringVar(&templateTag, "template-tag", "",
 		"when running a built version, and ldflag is set for the Kubefirst version, it will use this tag value to clone the templates (gitops and metaphor's)",
+	)
+	localCmd.Flags().StringVar(
+		&logLevel,
+		"log-level",
+		"debug",
+		"available log levels are: trace, debug, info, warning, error, fatal, panic",
 	)
 
 	// on error, doesnt show helper/usage

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"context"
 	"fmt"
 	"github.com/rs/zerolog/log"
 	"sync"
@@ -169,15 +168,15 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	//
 	// create local certs using MkCert tool
 	//
-	log.Println("installing CA from MkCert")
+	log.Info().Msg("installing CA from MkCert")
 	ssl.InstallCALocal(config)
-	log.Println("installing CA from MkCert done")
+	log.Info().Msg("installing CA from MkCert done")
 
-	log.Println("creating local certificates")
+	log.Info().Msg("creating local certificates")
 	if err := ssl.CreateCertificatesForLocalWrapper(config); err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
-	log.Println("creating local certificates done")
+	log.Info().Msg("creating local certificates done")
 
 	// add secrets to cluster
 	// todo there is a secret condition in AddK3DSecrets to this not checked

--- a/cmd/local/postrun.go
+++ b/cmd/local/postrun.go
@@ -1,7 +1,7 @@
 package local
 
 import (
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 	"os/signal"
 	"sync"
@@ -16,7 +16,7 @@ import (
 func runPostLocal(cmd *cobra.Command, args []string) error {
 
 	if !enableConsole {
-		log.Println("not calling console, console flag is disabled")
+		log.Info().Msg("not calling console, console flag is disabled")
 		return nil
 	}
 
@@ -46,7 +46,7 @@ func runPostLocal(cmd *cobra.Command, args []string) error {
 		close(MetaphorFrontendDevelopmentStopChannel)
 		close(MetaphorGoDevelopmentStopChannel)
 		close(MetaphorDevelopmentStopChannel)
-		log.Println("leaving port-forward command, port forwards are now closed")
+		log.Info().Msg("leaving port-forward command, port forwards are now closed")
 	}()
 
 	err := k8s.OpenPortForwardForLocal(
@@ -66,20 +66,20 @@ func runPostLocal(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Println("Starting the presentation of console and api for the handoff screen")
+	log.Info().Msg("Starting the presentation of console and api for the handoff screen")
 
 	err = pkg.IsConsoleUIAvailable(pkg.KubefirstConsoleLocalURL)
 	if err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
 	err = pkg.OpenBrowser(pkg.KubefirstConsoleLocalURL)
 	if err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
 
 	reports.LocalHandoffScreen(dryRun, silentMode)
 
-	log.Println("Kubefirst Console available at: http://localhost:9094", silentMode)
+	log.Info().Msgf("Kubefirst Console available at: http://localhost:9094", silentMode)
 
 	// managing termination signal from the terminal
 	sigs := make(chan os.Signal, 1)

--- a/cmd/local/postrun.go
+++ b/cmd/local/postrun.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"fmt"
 	"github.com/rs/zerolog/log"
 	"os"
 	"os/signal"
@@ -23,11 +24,11 @@ func runPostLocal(cmd *cobra.Command, args []string) error {
 
 	config := configs.ReadConfig()
 
-	log.Println("storing certificates into application secrets namespace")
+	log.Info().Msg("storing certificates into application secrets namespace")
 	if err := k8s.CreateSecretsFromCertificatesForLocalWrapper(config); err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
-	log.Println("storing certificates into application secrets namespace done")
+	log.Info().Msg("storing certificates into application secrets namespace done")
 
 	log.Info().Msg("Starting the presentation of console and api for the handoff screen")
 

--- a/cmd/local/prerun.go
+++ b/cmd/local/prerun.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubefirst/kubefirst/internal/services"
 	"github.com/kubefirst/kubefirst/internal/wrappers"
 	"github.com/kubefirst/kubefirst/pkg"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -20,6 +21,11 @@ import (
 )
 
 func validateLocal(cmd *cobra.Command, args []string) error {
+
+	// set log level
+	log.Info().Msgf("setting log level to: %s", logLevel)
+	zerologLevel := pkg.GetLogLevelByString(logLevel)
+	zerolog.SetGlobalLevel(zerologLevel)
 
 	config := configs.ReadConfig()
 

--- a/cmd/local/prerun.go
+++ b/cmd/local/prerun.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 	"github.com/dustin/go-humanize"
 	"github.com/kubefirst/kubefirst/configs"
@@ -164,7 +165,7 @@ func validateLocal(cmd *cobra.Command, args []string) error {
 		viper.Set("init.repos.gitops.cloned", true)
 		viper.Set(fmt.Sprintf("git.clone.%s.branch", repoName), gitOpsBranch)
 		if err = viper.WriteConfig(); err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 
 	} else {
@@ -186,7 +187,7 @@ func validateLocal(cmd *cobra.Command, args []string) error {
 		viper.Set(fmt.Sprintf("git.clone.%s.tag", repoName), tag)
 		viper.Set("init.repos.gitops.cloned", true)
 		if err = viper.WriteConfig(); err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 	}
 
@@ -200,7 +201,7 @@ func validateLocal(cmd *cobra.Command, args []string) error {
 	pkg.Detokenize(config.GitOpsLocalRepoPath)
 	viper.Set(fmt.Sprintf("init.repos.%s.detokenized", pkg.KubefirstGitOpsRepository), true)
 	if err = viper.WriteConfig(); err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
 
 	err = gitClient.CreateGitHubRemote(config.GitOpsLocalRepoPath, githubUser, pkg.KubefirstGitOpsRepository)

--- a/configs/kubefirstDirectory.go
+++ b/configs/kubefirstDirectory.go
@@ -2,7 +2,7 @@ package configs
 
 import (
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 )
 
@@ -11,10 +11,10 @@ func CheckKubefirstDir(config *Config) error {
 	k1sDir := fmt.Sprintf("%s", config.K1FolderPath)
 	if _, err := os.Stat(k1sDir); err != nil {
 		errorMsg := fmt.Sprintf("unable to load \".k1\" directory, error is: %s", err)
-		log.Println(errorMsg)
+		log.Error().Msg(errorMsg)
 		return fmt.Errorf(errorMsg)
 	}
 
-	log.Printf("\".k1\" directory found: %s", k1sDir)
+	log.Info().Msgf("\".k1\" directory found: %s", k1sDir)
 	return nil
 }

--- a/configs/kubefirstFile.go
+++ b/configs/kubefirstFile.go
@@ -2,7 +2,7 @@ package configs
 
 import (
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 )
 
@@ -11,10 +11,10 @@ func CheckKubefirstConfigFile(config *Config) error {
 	kubefirstFile := fmt.Sprintf("%s", config.KubefirstConfigFilePath)
 	if _, err := os.Stat(kubefirstFile); err != nil {
 		errorMsg := fmt.Sprintf("unable to load %q file, error is: %s", config.KubefirstConfigFilePath, err)
-		log.Println(errorMsg)
+		log.Error().Msg(errorMsg)
 		return fmt.Errorf(errorMsg)
 	}
 
-	log.Printf("%q file is set", config.KubefirstConfigFilePath)
+	log.Info().Msgf("%q file is set", config.KubefirstConfigFilePath)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -21,14 +21,15 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/go-logr/zerologr v1.2.2
 	github.com/google/go-github/v45 v45.0.0
 	github.com/google/uuid v1.1.2
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/vault/api v1.8.0
 	github.com/itchyny/gojq v0.12.8
 	github.com/jedib0t/go-pretty/v6 v6.3.1
 	github.com/ngrok/ngrok-go v0.0.0-20221014185124-b264c7d06bbf
 	github.com/otiai10/copy v1.7.0
+	github.com/rs/zerolog v1.28.0
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
@@ -85,7 +86,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/logr v1.2.3
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,7 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -227,6 +228,8 @@ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/zerologr v1.2.2 h1:nKJ1glUZQPURRpe20GaqCBgNyGYg9cylaerwrwKoogE=
+github.com/go-logr/zerologr v1.2.2/go.mod h1:eIsB+dwGuN3lAGytcpbXyBeiY8GKInIxy+Qwe+gI5lI=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
@@ -234,6 +237,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -314,8 +318,6 @@ github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2c
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -538,6 +540,9 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
+github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=

--- a/internal/downloadManager/download.go
+++ b/internal/downloadManager/download.go
@@ -82,7 +82,7 @@ func DownloadLocalTools(config *configs.Config) error {
 
 	select {
 	case <-wgDone:
-		log.Println("download finished")
+		log.Info().Msg("download finished")
 		return nil
 	case err = <-errorChannel:
 		close(errorChannel)

--- a/internal/downloadManager/download.go
+++ b/internal/downloadManager/download.go
@@ -6,9 +6,9 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"io"
 	"io/fs"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -51,7 +51,7 @@ func DownloadLocalTools(config *configs.Config) error {
 // the errorChannel will receive the error message, and process it back to the function caller.
 func DownloadTools(config *configs.Config) error {
 
-	log.Println("starting downloads...")
+	log.Info().Msg("starting downloads...")
 	toolsDirPath := fmt.Sprintf("%s/tools", config.K1FolderPath)
 
 	// create folder if it doesn't exist
@@ -79,7 +79,7 @@ func DownloadTools(config *configs.Config) error {
 			config.LocalOs,
 			config.LocalArchitecture,
 		)
-		log.Printf("Downloading kubectl from: %s", kubectlDownloadUrl)
+		log.Info().Msgf("Downloading kubectl from: %s", kubectlDownloadUrl)
 		err = downloadFile(config.KubectlClientPath, kubectlDownloadUrl)
 		if err != nil {
 			errorChannel <- err
@@ -92,16 +92,16 @@ func DownloadTools(config *configs.Config) error {
 			return
 		}
 
-		log.Println("going to print the kubeconfig env in runtime", os.Getenv("KUBECONFIG"))
+		log.Info().Msgf("going to print the kubeconfig env in runtime: %s", os.Getenv("KUBECONFIG"))
 
 		kubectlStdOut, kubectlStdErr, err := pkg.ExecShellReturnStrings(config.KubectlClientPath, "version", "--client", "--short")
-		log.Printf("-> kubectl version:\n\t%s\n\t%s\n", kubectlStdOut, kubectlStdErr)
+		log.Info().Msgf("-> kubectl version:\n\t%s\n\t%s\n", kubectlStdOut, kubectlStdErr)
 		if err != nil {
 			errorChannel <- fmt.Errorf("failed to call kubectlVersionCmd.Run(): %v", err)
 			return
 		}
 		wg.Done()
-		log.Println("Kubectl download finished")
+		log.Info().Msg("Kubectl download finished")
 	}()
 
 	go func() {
@@ -116,7 +116,7 @@ func DownloadTools(config *configs.Config) error {
 			config.LocalOs,
 			config.LocalArchitecture,
 		)
-		log.Printf("Downloading terraform from %s", terraformDownloadUrl)
+		log.Info().Msgf("Downloading terraform from %s", terraformDownloadUrl)
 		terraformDownloadZipPath := fmt.Sprintf("%s/tools/terraform.zip", config.K1FolderPath)
 		err = downloadFile(terraformDownloadZipPath, terraformDownloadUrl)
 		if err != nil {
@@ -144,7 +144,7 @@ func DownloadTools(config *configs.Config) error {
 			return
 		}
 		wg.Done()
-		log.Println("Terraform download finished")
+		log.Info().Msg("Terraform download finished")
 	}()
 
 	go func() {
@@ -155,7 +155,7 @@ func DownloadTools(config *configs.Config) error {
 			config.LocalOs,
 			config.LocalArchitecture,
 		)
-		log.Printf("Downloading terraform from %s", helmDownloadUrl)
+		log.Info().Msgf("Downloading terraform from %s", helmDownloadUrl)
 		helmDownloadTarGzPath := fmt.Sprintf("%s/tools/helm.tar.gz", config.K1FolderPath)
 
 		err = downloadFile(helmDownloadTarGzPath, helmDownloadUrl)
@@ -194,11 +194,11 @@ func DownloadTools(config *configs.Config) error {
 			return
 		}
 
-		log.Printf("-> Helm version:\n\t%s\n\t%s\n", helmStdOut, helmStdErr)
+		log.Info().Msgf("-> Helm version: %s\n\t%s", helmStdOut, helmStdErr)
 
 		wg.Done()
 
-		log.Println("Helm download finished")
+		log.Info().Msg("Helm download finished")
 
 	}()
 
@@ -209,7 +209,7 @@ func DownloadTools(config *configs.Config) error {
 
 	select {
 	case <-wgDone:
-		log.Println("downloads finished")
+		log.Info().Msg("downloads finished")
 		return nil
 	case err = <-errorChannel:
 		close(errorChannel)
@@ -250,7 +250,7 @@ func downloadFile(localFilename string, url string) error {
 func extractFileFromTarGz(gzipStream io.Reader, tarAddress string, targetFilePath string) {
 	uncompressedStream, err := gzip.NewReader(gzipStream)
 	if err != nil {
-		log.Panicf("extractTarGz: NewReader failed")
+		log.Panic().Msg("extractTarGz: NewReader failed")
 	}
 
 	tarReader := tar.NewReader(uncompressedStream)
@@ -261,23 +261,23 @@ func extractFileFromTarGz(gzipStream io.Reader, tarAddress string, targetFilePat
 			break
 		}
 		if err != nil {
-			log.Panicf("extractTarGz: Next() failed: %s", err.Error())
+			log.Panic().Msgf("extractTarGz: Next() failed: %s", err.Error())
 		}
-		log.Println(header.Name)
+		log.Info().Msg(header.Name)
 		if header.Name == tarAddress {
 			switch header.Typeflag {
 			case tar.TypeReg:
 				outFile, err := os.Create(targetFilePath)
 				if err != nil {
-					log.Panicf("extractTarGz: Create() failed: %s", err.Error())
+					log.Panic().Msgf("extractTarGz: Create() failed: %s", err.Error())
 				}
 				if _, err := io.Copy(outFile, tarReader); err != nil {
-					log.Panicf("extractTarGz: Copy() failed: %s", err.Error())
+					log.Panic().Msgf("extractTarGz: Copy() failed: %s", err.Error())
 				}
 				outFile.Close()
 
 			default:
-				log.Printf(
+				log.Info().Msgf(
 					"extractTarGz: uknown type: %s in %s\n",
 					string(header.Typeflag),
 					header.Name)
@@ -297,13 +297,13 @@ func unzip(zipFilepath string, unzipDirectory string) error {
 
 	for _, f := range archive.File {
 		filePath := filepath.Join(dst, f.Name)
-		log.Println("unzipping file ", filePath)
+		log.Info().Msgf("unzipping file %s", filePath)
 
 		if !strings.HasPrefix(filePath, filepath.Clean(dst)+string(os.PathSeparator)) {
 			return errors.New("invalid file path")
 		}
 		if f.FileInfo().IsDir() {
-			log.Println("creating directory...")
+			log.Info().Msg("creating directory...")
 			err = os.MkdirAll(filePath, os.ModePerm)
 			if err != nil {
 				return err

--- a/internal/k3d/create.go
+++ b/internal/k3d/create.go
@@ -2,7 +2,7 @@ package k3d
 
 import (
 	"errors"
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 	"time"
 
@@ -13,7 +13,7 @@ import (
 
 // CreateK3dCluster create an k3d cluster
 func CreateK3dCluster() error {
-	log.Println("Create K3d cluster for local install")
+	log.Info().Msg("creating K3d cluster...")
 	config := configs.ReadConfig()
 	// I tried Terraform templates using: https://registry.terraform.io/providers/pvotal-tech/k3d/latest/docs/resources/cluster
 	// it didn't worked as expected.
@@ -28,7 +28,7 @@ func CreateK3dCluster() error {
 			"--k3s-arg", `--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@agent:*`,
 			"--k3s-arg", `--kubelet-arg=eviction-minimum-reclaim=imagefs.available=1%,nodefs.available=1%@agent:*`)
 		if err != nil {
-			log.Println("error creating k3d cluster")
+			log.Info().Msg("error creating k3d cluster")
 			return errors.New("error creating k3d cluster")
 		}
 
@@ -37,23 +37,23 @@ func CreateK3dCluster() error {
 		///gitops/terraform/base/
 		_ = os.MkdirAll(config.KubeConfigFolder, 0777)
 
-		log.Println(config.K3dPath, "kubeconfig", "get", viper.GetString("cluster-name"), ">", config.KubeConfigPath)
+		log.Info().Msgf(config.K3dPath, "kubeconfig", "get", viper.GetString("cluster-name"), ">", config.KubeConfigPath)
 		out, _, err := pkg.ExecShellReturnStrings(config.K3dPath, "kubeconfig", "get", viper.GetString("cluster-name"))
 		if err != nil {
 			return err
 		}
-		log.Println(config.KubeConfigPath)
+		log.Info().Msg(config.KubeConfigPath)
 
 		kubeConfig := []byte(out)
 		err = os.WriteFile(config.KubeConfigPath, kubeConfig, 0644)
 		if err != nil {
-			log.Println("error updating config:", err)
+			log.Info().Msgf("error updating config:", err)
 			return errors.New("error updating config")
 		}
 		viper.Set("k3d.created", true)
 		viper.WriteConfig()
 	} else {
-		log.Println("K3d Cluster already created")
+		log.Info().Msg("K3d Cluster already created")
 	}
 	return nil
 }

--- a/internal/k3d/destroy.go
+++ b/internal/k3d/destroy.go
@@ -2,7 +2,7 @@ package k3d
 
 import (
 	"errors"
-	"log"
+	"github.com/rs/zerolog/log"
 	"time"
 
 	"github.com/kubefirst/kubefirst/configs"
@@ -12,13 +12,14 @@ import (
 
 // DeleteK3dCluster delete a k3d cluster
 func DeleteK3dCluster() error {
-	log.Println("Delete K3d cluster ", viper.GetString("cluster-name"))
+	log.Info().Msgf("Delete K3d cluster %s", viper.GetString("cluster-name"))
 	config := configs.ReadConfig()
 	_, _, err := pkg.ExecShellReturnStrings(config.K3dPath, "cluster", "delete", viper.GetString("cluster-name"))
 	if err != nil {
-		log.Println("error deleting k3d cluster")
+		log.Info().Msg("error deleting k3d cluster")
 		return errors.New("error deleting k3d cluster")
 	}
+	// todo: remove it?
 	time.Sleep(20 * time.Second)
 
 	return nil

--- a/internal/k3d/secrets.go
+++ b/internal/k3d/secrets.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 
 	"github.com/kubefirst/kubefirst/internal/k8s"
@@ -22,11 +22,11 @@ func AddK3DSecrets(dryrun bool) error {
 		namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s}}
 		_, err = clientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
 		if err != nil {
-			log.Println("Error:", s)
+			log.Error().Err(err).Msg("")
 			return errors.New("error creating namespace")
 		}
-		log.Println(i, s)
-		log.Println("Namespace Created:", s)
+		log.Info().Msgf("%d, %s", i, s)
+		log.Info().Msgf("Namespace Created: %s", s)
 	}
 
 	dataArgo := map[string][]byte{
@@ -39,7 +39,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("argo").Create(context.TODO(), argoSecret, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: argo/minio-creds")
 	}
 	viper.Set("kubernetes.argo-minio.secret.created", true)
@@ -59,7 +59,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("argo").Create(context.TODO(), argoCiSecrets, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: argo/ci-secrets")
 	}
 	viper.Set("kubernetes.argo-ci.secret.created", true)
@@ -75,7 +75,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("argo").Create(context.TODO(), argoDockerSecrets, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: argo/docker-config")
 	}
 
@@ -86,7 +86,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("development").Create(context.TODO(), developmentDockerSecrets, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: development/docker-config")
 	}
 
@@ -97,7 +97,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("staging").Create(context.TODO(), stagingDockerSecrets, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: staging/docker-config")
 	}
 
@@ -108,7 +108,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("production").Create(context.TODO(), productionDockerSecrets, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: production/docker-config")
 	}
 	viper.Set("kubernetes.argo-docker.secret.created", true)
@@ -131,7 +131,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("argocd").Create(context.TODO(), argoCdSecret, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: argo/minio-creds")
 	}
 	viper.Set("kubernetes.argo-minio.secret.created", true)
@@ -164,7 +164,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("atlantis").Create(context.TODO(), atlantisSecret, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: atlantis/atlantis-secrets")
 	}
 	viper.Set("kubernetes.atlantis.secret.created", true)
@@ -182,7 +182,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("chartmuseum").Create(context.TODO(), chartmuseumSecret, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: chartmuseum/chartmuseum")
 	}
 	viper.Set("kubernetes.chartmuseum.secret.created", true)
@@ -197,7 +197,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("github-runner").Create(context.TODO(), ghRunnerSecret, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: github-runner/controller-manager")
 	}
 	viper.Set("kubernetes.github-runner.secret.created", true)
@@ -212,7 +212,7 @@ func AddK3DSecrets(dryrun bool) error {
 	}
 	_, err = clientset.CoreV1().Secrets("vault").Create(context.TODO(), vaultSecret, metav1.CreateOptions{})
 	if err != nil {
-		log.Println("Error:", err)
+		log.Error().Err(err).Msg("")
 		return errors.New("error creating kubernetes secret: github-runner/controller-manager")
 	}
 	viper.Set("kubernetes.vault.secret.created", true)

--- a/internal/k8s/kubernetes.go
+++ b/internal/k8s/kubernetes.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -46,7 +46,7 @@ type PatchJson struct {
 func GetPodNameByLabel(podsClient coreV1Types.PodInterface, label string) string {
 	pods, err := podsClient.List(context.TODO(), metaV1.ListOptions{LabelSelector: label})
 	if err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
 
 	gitlabToolboxPodName = pods.Items[0].Name
@@ -57,16 +57,16 @@ func GetPodNameByLabel(podsClient coreV1Types.PodInterface, label string) string
 func DeletePodByLabel(podsClient coreV1Types.PodInterface, label string) {
 	err := podsClient.DeleteCollection(context.TODO(), metaV1.DeleteOptions{}, metaV1.ListOptions{LabelSelector: label})
 	if err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	} else {
-		log.Printf("Success delete of pods with label(%s).", label)
+		log.Info().Msgf("Success delete of pods with label(%s).", label)
 	}
 }
 
 func GetSecretValue(k8sClient coreV1Types.SecretInterface, secretName, key string) string {
 	secret, err := k8sClient.Get(context.TODO(), secretName, metaV1.GetOptions{})
 	if err != nil {
-		log.Println(fmt.Sprintf("error getting key: %s from secret: %s", key, secretName), err)
+		log.Error().Err(err).Msgf("error getting key: %s from secret: %s", key, secretName)
 	}
 	return string(secret.Data[key])
 }
@@ -75,18 +75,18 @@ func DeleteRegistryApplication(skipDeleteRegistryApplication bool) {
 
 	if !skipDeleteRegistryApplication {
 
-		log.Println("refreshing argocd session token")
+		log.Info().Msgf("refreshing argocd session token")
 		argocd.GetArgocdAuthToken(false)
 
 		url := "https://localhost:8080/api/v1/applications/registry"
 		_, _, err := pkg.ExecShellReturnStrings("curl", "-k", "-vL", "-X", "DELETE", url, "-H", fmt.Sprintf("Authorization: Bearer %s", viper.GetString("argocd.admin.apitoken")))
 		if err != nil {
-			log.Panicf("error: delete registry applicatoin from argocd failed: %s", err)
+			log.Panic().Err(err).Msg("error: delete registry applicatoin from argocd failed")
 		}
-		log.Println("waiting for argocd deletion to complete")
+		log.Info().Msg("waiting for argocd deletion to complete")
 		time.Sleep(300 * time.Second)
 	} else {
-		log.Println("skip:  deleteRegistryApplication")
+		log.Info().Msg("skip:  deleteRegistryApplication")
 	}
 }
 
@@ -152,7 +152,7 @@ func GetResourcesByJq(dynamic dynamic.Interface, ctx context.Context, group stri
 			} else {
 				boolResult, ok := result.(bool)
 				if !ok {
-					fmt.Println("Query returned non-boolean value")
+					log.Info().Msg("Query returned non-boolean value")
 				} else if boolResult {
 					resources = append(resources, item)
 				}
@@ -165,19 +165,19 @@ func GetResourcesByJq(dynamic dynamic.Interface, ctx context.Context, group stri
 // GetClientSet - Get reference to k8s credentials to use APIS
 func GetClientSet(dryRun bool) (*kubernetes.Clientset, error) {
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, GetClientSet skipped.")
+		log.Info().Msgf("[#99] Dry-run mode, GetClientSet skipped.")
 		return nil, nil
 	}
 	config := configs.ReadConfig()
 
 	kubeconfig, err := clientcmd.BuildConfigFromFlags("", config.KubeConfigPath)
 	if err != nil {
-		log.Printf("Error getting kubeconfig: %s", err)
+		log.Error().Err(err).Msg("Error getting kubeconfig")
 		return nil, err
 	}
 	clientset, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		log.Printf("Error getting clientset: %s", err)
+		log.Error().Err(err).Msg("Error getting clientset")
 		return clientset, err
 	}
 
@@ -188,7 +188,7 @@ func GetClientSet(dryRun bool) (*kubernetes.Clientset, error) {
 // PortForward - opens port-forward to services
 func PortForward(dryRun bool, namespace string, filter string, ports string) (*exec.Cmd, error) {
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, K8sPortForward skipped.")
+		log.Info().Msg("[#99] Dry-run mode, K8sPortForward skipped.")
 		return nil, nil
 	}
 	config := configs.ReadConfig()
@@ -200,7 +200,7 @@ func PortForward(dryRun bool, namespace string, filter string, ports string) (*e
 	err := kPortForward.Start()
 
 	// make port forward port available for log
-	log.Printf("kubectl port-forward started for (%s) available at http://localhost:%s", filter, strings.Split(ports, ":")[0])
+	log.Info().Msgf("kubectl port-forward started for (%s) available at http://localhost:%s", filter, strings.Split(ports, ":")[0])
 	//defer kPortForwardVault.Process.Signal(syscall.SIGTERM)
 
 	//Please, don't remove this sleep, pf takes a while to be ready to search calls.
@@ -208,12 +208,12 @@ func PortForward(dryRun bool, namespace string, filter string, ports string) (*e
 	//this sleep protects that.
 	//Please, don't remove this comment either.
 	time.Sleep(time.Second * 5)
-	log.Println(config.KubectlClientPath, " ", "--kubeconfig", " ", config.KubeConfigPath, " ", "-n", " ", namespace, " ", "port-forward", " ", filter, " ", ports)
+	log.Info().Msgf("%s %s %s %s %s %s %s %s", config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "-n", namespace, "port-forward", filter, ports)
 	if err != nil {
 		// If it doesn't error, we kinda don't care much.
-		log.Printf("Commad Execution STDOUT: %s", kPortForwardOutb.String())
-		log.Printf("Commad Execution STDERR: %s", kPortForwardErrb.String())
-		log.Printf("error: failed to port-forward to %s in main thread %s", filter, err)
+		log.Info().Msgf("Commad Execution STDOUT: %s", kPortForwardOutb.String())
+		log.Error().Err(err).Msgf("Commad Execution STDERR: %s", kPortForwardErrb.String())
+		log.Error().Err(err).Msgf("$error: failed to port-forward to %s in main thread", filter)
 		return kPortForward, err
 	}
 
@@ -222,7 +222,7 @@ func PortForward(dryRun bool, namespace string, filter string, ports string) (*e
 
 func WaitForNamespaceandPods(dryRun bool, config *configs.Config, namespace, podLabel string) {
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, WaitForNamespaceandPods skipped")
+		log.Info().Msg("[#99] Dry-run mode, WaitForNamespaceandPods skipped")
 		return
 	}
 	if !viper.GetBool("create.softserve.ready") {
@@ -230,10 +230,10 @@ func WaitForNamespaceandPods(dryRun bool, config *configs.Config, namespace, pod
 		for i := 0; i < x; i++ {
 			_, _, err := pkg.ExecShellReturnStrings(config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "-n", namespace, "get", fmt.Sprintf("namespace/%s", namespace))
 			if err != nil {
-				log.Println(fmt.Sprintf("waiting for %s namespace to create ", namespace))
+				log.Info().Msg(fmt.Sprintf("waiting for %s namespace to create ", namespace))
 				time.Sleep(10 * time.Second)
 			} else {
-				log.Println(fmt.Sprintf("namespace %s found, continuing", namespace))
+				log.Info().Msg(fmt.Sprintf("namespace %s found, continuing", namespace))
 				time.Sleep(10 * time.Second)
 				i = 51
 			}
@@ -241,10 +241,10 @@ func WaitForNamespaceandPods(dryRun bool, config *configs.Config, namespace, pod
 		for i := 0; i < x; i++ {
 			_, _, err := pkg.ExecShellReturnStrings(config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "-n", namespace, "get", "pods", "-l", podLabel)
 			if err != nil {
-				log.Println(fmt.Sprintf("waiting for %s pods to create ", namespace))
+				log.Info().Msg(fmt.Sprintf("waiting for %s pods to create ", namespace))
 				time.Sleep(10 * time.Second)
 			} else {
-				log.Println(fmt.Sprintf("%s pods found, continuing", namespace))
+				log.Info().Msg(fmt.Sprintf("%s pods found, continuing", namespace))
 				time.Sleep(10 * time.Second)
 				break
 			}
@@ -252,14 +252,14 @@ func WaitForNamespaceandPods(dryRun bool, config *configs.Config, namespace, pod
 		viper.Set("create.softserve.ready", true)
 		viper.WriteConfig()
 	} else {
-		log.Println("soft-serve is ready, skipping")
+		log.Info().Msg("soft-serve is ready, skipping")
 	}
 }
 
 func PatchSecret(k8sClient coreV1Types.SecretInterface, secretName, key, val string) {
 	secret, err := k8sClient.Get(context.TODO(), secretName, metaV1.GetOptions{})
 	if err != nil {
-		log.Println(fmt.Sprintf("error getting key: %s from secret: %s", key, secretName), err)
+		log.Error().Err(err).Msgf("error getting key: %s from secret: %s", key, secretName)
 	}
 	secret.Data[key] = []byte(val)
 	k8sClient.Update(context.TODO(), secret, metaV1.UpdateOptions{})
@@ -267,7 +267,7 @@ func PatchSecret(k8sClient coreV1Types.SecretInterface, secretName, key, val str
 
 func CreateVaultConfiguredSecret(dryRun bool, config *configs.Config) {
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, CreateVaultConfiguredSecret skipped.")
+		log.Info().Msg("[#99] Dry-run mode, CreateVaultConfiguredSecret skipped.")
 		return
 	}
 	if !viper.GetBool("vault.configuredsecret") {
@@ -280,20 +280,20 @@ func CreateVaultConfiguredSecret(dryRun bool, config *configs.Config) {
 		k.Stderr = os.Stderr
 		err := k.Run()
 		if err != nil {
-			log.Panicf("failed to create secret for vault-configured: %s", err)
+			log.Panic().Err(err).Msg("failed to create secret for vault-configured")
 		}
-		log.Printf("the secret create output is: %s", output.String())
+		log.Info().Msgf("the secret create output is: %s", output.String())
 
 		viper.Set("vault.configuredsecret", true)
 		viper.WriteConfig()
 	} else {
-		log.Println("vault secret already created")
+		log.Info().Msg("vault secret already created")
 	}
 }
 
 func WaitForGitlab(dryRun bool, config *configs.Config) {
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, WaitForGitlab skipped.")
+		log.Info().Msg("[#99] Dry-run mode, WaitForGitlab skipped.")
 		return
 	}
 	var output bytes.Buffer
@@ -304,25 +304,25 @@ func WaitForGitlab(dryRun bool, config *configs.Config) {
 	k.Stderr = os.Stderr
 	err := k.Run()
 	if err != nil {
-		log.Panicf("failed to execute kubectl wait for gitlab pods with label app=webservice: %s \n%s", output.String(), err)
+		log.Panic().Msgf("failed to execute kubectl wait for gitlab pods with label app=webservice: %s \n%s", output.String())
 	}
-	log.Printf("the output is: %s", output.String())
+	log.Info().Msgf("the output is: %s", output.String())
 }
 
 func RemoveSelfSignedCertArgoCD(argocdPodClient coreV1Types.PodInterface) error {
-	log.Printf("Removing Self-Signed Certificate from argocd-secret")
+	log.Info().Msg("Removing Self-Signed Certificate from argocd-secret")
 
-	log.Printf("Removing tls.crt")
+	log.Info().Msgf("Removing tls.crt")
 	err := clearSecretField("argocd", "argocd-secret", "/data/tls.crt")
 	if err != nil {
-		log.Printf("err removing tls.crt from argo-secret: %s", err)
+		log.Error().Err(err).Msg("errror removing tls.crt from argo-secret")
 		return err
 	}
 
-	log.Printf("Removing tls.key")
+	log.Info().Msgf("Removing tls.key")
 	err = clearSecretField("argocd", "argocd-secret", "/data/tls.key")
 	if err != nil {
-		log.Printf("err removing tls.crt from argo-secret: %s", err)
+		log.Error().Err(err).Msg("error removing tls.crt from argo-secret")
 		return err
 	}
 
@@ -334,7 +334,7 @@ func RemoveSelfSignedCertArgoCD(argocdPodClient coreV1Types.PodInterface) error 
 
 // remove field from k8s secret using sdk
 func clearSecretField(namespace, name, field string) error {
-	log.Printf("Prepare secret to be patched: ns: %s name: %s path: %s", namespace, name, field)
+	log.Info().Msgf("Prepare secret to be patched: ns: %s name: %s path: %s", namespace, name, field)
 	secret := secret{
 		namespace: namespace,
 		name:      name,
@@ -347,13 +347,13 @@ func clearSecretField(namespace, name, field string) error {
 
 	clientset, err := GetClientSet(false)
 	if err != nil {
-		log.Printf("Error creating k8s clientset : %s", err)
+		log.Error().Err(err).Msg("error creating k8s clientset")
 		return err
 	}
 
 	err = secret.patchSecret(clientset, payload)
 	if err != nil {
-		log.Printf("Error calling patchSecret : %s", err)
+		log.Error().Err(err).Msg("error calling patchSecret")
 		return err
 	}
 	return nil
@@ -363,11 +363,11 @@ func (p *secret) patchSecret(k8sClient *kubernetes.Clientset, payload []PatchJso
 
 	payloadBytes, _ := json.Marshal(payload)
 
-	log.Printf("Patching secret on K8S via SDK")
+	log.Info().Msg("Patching secret on K8S via SDK")
 	_, err := k8sClient.CoreV1().Secrets(p.namespace).Patch(context.TODO(), p.name, k8sTypes.JSONPatchType, payloadBytes, metaV1.PatchOptions{})
 
 	if err != nil {
-		log.Printf("Error patching secret : %s", err)
+		log.Error().Err(err).Msg("error patching secret ")
 		return err
 	}
 	return nil
@@ -376,7 +376,7 @@ func (p *secret) patchSecret(k8sClient *kubernetes.Clientset, payload []PatchJso
 // todo: deprecate the other functions
 func LoopUntilPodIsReady(dryRun bool) {
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, loopUntilPodIsReady skipped.")
+		log.Info().Msg("[#99] Dry-run mode, loopUntilPodIsReady skipped.")
 		return
 	}
 	token := viper.GetString("vault.token")
@@ -385,7 +385,7 @@ func LoopUntilPodIsReady(dryRun bool) {
 		totalAttempts := 50
 		url := "http://localhost:8200/v1/sys/health"
 		for i := 0; i < totalAttempts; i++ {
-			log.Printf("vault is not ready yet, sleeping and checking again, attempt (%d/%d)", i+1, totalAttempts)
+			log.Info().Msgf("vault is not ready yet, sleeping and checking again, attempt (%d/%d)", i+1, totalAttempts)
 			time.Sleep(10 * time.Second)
 
 			req, _ := http.NewRequest("GET", url, nil)
@@ -394,13 +394,13 @@ func LoopUntilPodIsReady(dryRun bool) {
 
 			res, err := http.DefaultClient.Do(req)
 			if err != nil {
-				log.Println("error with http request Do, vault is not available", err)
+				log.Warn().Err(err).Msg("error with http request Do, vault is not available")
 				// todo: temporary code
-				log.Println("trying to open port-forward again...")
+				log.Info().Msgf("trying to open port-forward again...")
 				go func() {
 					_, err := PortForward(false, "vault", "svc/vault", "8200:8200")
 					if err != nil {
-						log.Println("error opening Vault port forward")
+						log.Error().Err(err).Msg("error opening Vault port forward")
 					}
 				}()
 				continue
@@ -409,35 +409,35 @@ func LoopUntilPodIsReady(dryRun bool) {
 			defer res.Body.Close()
 			body, err := io.ReadAll(res.Body)
 			if err != nil {
-				log.Println("vault is available but the body is not what is expected ", err)
+				log.Error().Err(err).Msg("vault is available but the body is not what is expected")
 				continue
 			}
 
 			var responseJson map[string]interface{}
 
-			if err := json.Unmarshal(body, &responseJson); err != nil {
-				log.Printf("vault is available but the body is not what is expected %s", err)
+			if err = json.Unmarshal(body, &responseJson); err != nil {
+				log.Error().Err(err).Msg("vault is available but the body is not what is expected")
 				continue
 			}
 
 			_, ok := responseJson["initialized"]
 			if ok {
-				log.Printf("vault is initialized and is in the expected state")
+				log.Info().Msgf("vault is initialized and is in the expected state")
 				return
 			}
-			log.Panic("vault was never initialized")
+			log.Panic().Msg("vault was never initialized")
 		}
 		viper.Set("vault.status.running", true)
 		viper.WriteConfig()
 	} else {
-		log.Println("vault token already exists, skipping vault health checks loopUntilPodIsReady")
+		log.Info().Msgf("vault token already exists, skipping vault health checks loopUntilPodIsReady")
 	}
 }
 
 // todo: deprecate the other functions
 func SetArgocdCreds(dryRun bool) {
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, setArgocdCreds skipped.")
+		log.Info().Msg("[#99] Dry-run mode, setArgocdCreds skipped.")
 		viper.Set("argocd.admin.password", "dry-run-not-real-pwd")
 		viper.Set("argocd.admin.username", "dry-run-not-admin")
 		viper.WriteConfig()
@@ -451,7 +451,7 @@ func SetArgocdCreds(dryRun bool) {
 
 	argocdPassword := GetSecretValue(argocd.ArgocdSecretClient, "argocd-initial-admin-secret", "password")
 	if argocdPassword == "" {
-		log.Panicf("Missing argocdPassword")
+		log.Panic().Msg("Missing argocdPassword")
 	}
 
 	viper.Set("argocd.admin.password", argocdPassword)

--- a/internal/k8s/portForward.go
+++ b/internal/k8s/portForward.go
@@ -77,7 +77,7 @@ func PortForwardPod(clientset *kubernetes.Clientset, req PortForwardAPodRequest)
 	}
 
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", runningPod.Namespace, runningPod.Name)
-	hostIP := strings.TrimLeft(req.RestConfig.Host, "htps:/")
+	hostIP := strings.TrimLeft(req.RestConfig.Host, "https:/")
 
 	transport, upgrader, err := spdy.RoundTripperFor(req.RestConfig)
 	if err != nil {

--- a/internal/k8s/wrappers.go
+++ b/internal/k8s/wrappers.go
@@ -251,7 +251,7 @@ func CreateSecretsFromCertificatesForLocalWrapper(config *configs.Config) error 
 		// save content into secret
 		err = CreateSecret(app.Namespace, app.AppName+"-tls", data)
 		if err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 
 		log.Printf("creating TLS k8s secret for %s done", app.AppName)

--- a/internal/k8s/wrappers.go
+++ b/internal/k8s/wrappers.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	"log"
+	"github.com/rs/zerolog/log"
 	"sync"
 
 	"github.com/kubefirst/kubefirst/configs"
@@ -104,7 +104,7 @@ func OpenPortForwardForLocal(
 	return nil
 }
 
-// OpenPortForwardWrapper wrapper for PortForwardPod function. This functions make it easier to open and close port
+// OpenPortForwardPodWrapper wrapper for PortForwardPod function. This functions make it easier to open and close port
 // forward request. By providing the function parameters, the function will manage to create the port forward. The
 // parameter for the stopChannel controls when the port forward must be closed.
 //
@@ -126,7 +126,7 @@ func OpenPortForwardPodWrapper(podName string, namespace string, podPort int, po
 	kubeconfig := config1.KubeConfigPath
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
 
 	// readyCh communicate when the port forward is ready to get traffic
@@ -153,21 +153,22 @@ func OpenPortForwardPodWrapper(podName string, namespace string, podPort int, po
 	go func() {
 		err = PortForwardPod(clientset, portForwardRequest)
 		if err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 	}()
 
 	select {
 	case <-stopChannel:
-		log.Println("leaving...")
+		log.Info().Msg("leaving...")
 		close(stopChannel)
 		close(readyCh)
 		break
 	case <-readyCh:
-		log.Println("port forwarding is ready to get traffic")
+		log.Info().Msg("port forwarding is ready to get traffic")
 	}
 
-	log.Printf("Pod %q at namespace %q has port-forward accepting local connections at port %d\n", podName, namespace, podLocalPort)
+	log.Info().Msgf("Pod %q at namespace %q has port-forward accepting local connections at port %d\n", podName, namespace, podLocalPort)
+
 	//<-stopChannel
 	return
 }
@@ -178,7 +179,7 @@ func OpenPortForwardServiceWrapper(serviceName string, namespace string, service
 	kubeconfig := config1.KubeConfigPath
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
 
 	// readyCh communicate when the port forward is ready to get traffic
@@ -205,21 +206,20 @@ func OpenPortForwardServiceWrapper(serviceName string, namespace string, service
 	go func() {
 		err = PortForwardService(clientset, portForwardRequest)
 		if err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 	}()
 
 	select {
 	case <-stopChannel:
-		log.Println("leaving...")
+		log.Info().Msg("leaving...")
 		close(stopChannel)
 		close(readyCh)
 		break
 	case <-readyCh:
-		log.Println("port forwarding is ready to get traffic")
+		log.Info().Msg("port forwarding is ready to get traffic")
 	}
 
-	log.Printf("Service %q at namespace %q has port-forward accepting local connections at port %d\n", serviceName, namespace, serviceLocalPort)
-	//<-stopChannel
+	log.Info().Msgf("Service %q at namespace %q has port-forward accepting local connections at port %d\n", serviceName, namespace, serviceLocalPort)
 	return
 }

--- a/internal/repo/kubefirstTemplate.go
+++ b/internal/repo/kubefirstTemplate.go
@@ -138,7 +138,7 @@ func PrepareKubefirstTemplateRepo(dryRun bool, config *configs.Config, githubOrg
 
 // UpdateForLocalMode - Tweak for local install on templates
 func UpdateForLocalMode(directory string) error {
-	log.Info().Msgf("Working Directory:", directory)
+	log.Info().Msgf("Working Directory: %s", directory)
 	//Tweak folder
 	os.RemoveAll(directory + "/components")
 	os.RemoveAll(directory + "/registry")

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -570,7 +570,7 @@ func UpdateTerraformS3BackendForLocalhostAddress() error {
 			"http://minio.minio.svc.cluster.local:9000",
 			MinioURL,
 		); err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 	}
 

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -134,7 +134,7 @@ func DetokenizeDirectory(path string, fi os.FileInfo, err error) error {
 
 		ngrokURL, err := url.Parse(viper.GetString("ngrok.url"))
 		if err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 
 		githubToken := os.Getenv("KUBEFIRST_GITHUB_AUTH_TOKEN")

--- a/pkg/keys.go
+++ b/pkg/keys.go
@@ -6,7 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 	"strings"
 
@@ -26,34 +26,34 @@ func CreateSshKeyPair() {
 	// generate GitLab keys
 	if publicKey == "" && viper.GetString("gitprovider") == "gitlab" {
 
-		log.Println("generating new key pair for GitLab")
+		log.Info().Msg("generating new key pair for GitLab")
 		publicKey, privateKey, err := generateGitLabKeys()
 		if err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 
 		viper.Set("botpublickey", publicKey)
 		viper.Set("botprivatekey", privateKey)
 		err = viper.WriteConfig()
 		if err != nil {
-			log.Panicf("error: could not write to viper config")
+			log.Panic().Msg("error: could not write to viper config")
 		}
 	}
 
 	// generate GitHub keys
 	if publicKey == "" && viper.GetString("gitprovider") == "github" {
 
-		log.Println("generating new key pair for GitHub")
+		log.Info().Msg("generating new key pair for GitHub")
 		publicKey, privateKey, err := generateGitHubKeys()
 		if err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 
 		viper.Set("botpublickey", publicKey)
 		viper.Set("botprivatekey", privateKey)
 		err = viper.WriteConfig()
 		if err != nil {
-			log.Panicf("error: could not write to viper config")
+			log.Panic().Msg("error: could not write to viper config")
 		}
 
 	}
@@ -77,8 +77,9 @@ configs:
 
 	err := os.WriteFile(fmt.Sprintf("%s/argocd-init-values.yaml", config.K1FolderPath), argocdInitValuesYaml, 0644)
 	if err != nil {
-		log.Panicf("error: could not write argocd-init-values.yaml %s", err)
+		log.Panic().Msg("error: could not write to viper config")
 	}
+
 }
 
 func PublicKey() (*goGitSsh.PublicKeys, error) {
@@ -144,13 +145,14 @@ func ModConfigYaml() {
 
 	file, err := os.ReadFile("./config.yaml")
 	if err != nil {
-		log.Println("error reading file", err)
+		log.Error().Err(err).Msg("error reading file")
 	}
 
 	newFile := strings.Replace(string(file), "allow-keyless: false", "allow-keyless: true", -1)
 
 	err = os.WriteFile("./config.yaml", []byte(newFile), 0)
 	if err != nil {
-		panic(err)
+		log.Panic().Msg("error: could not write to viper config")
 	}
+
 }

--- a/pkg/log.go
+++ b/pkg/log.go
@@ -22,5 +22,32 @@ func ZerologSetup(logFile *os.File) zerolog.Logger {
 		return file + ":" + strconv.Itoa(line)
 	}
 
-	return log.Output(zerolog.ConsoleWriter{Out: logFile, NoColor: false}).With().Caller().Logger()
+	// default log level
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+
+	return log.Output(zerolog.ConsoleWriter{Out: logFile, NoColor: true}).With().Caller().Logger()
+	//return log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}).With().Caller().Logger()
+}
+
+// GetLogLevelByString receives a log level string, and returns it's related zerolog Level iota
+// panic (zerolog.PanicLevel, 5)
+// fatal (zerolog.FatalLevel, 4)
+// error (zerolog.ErrorLevel, 3)
+// warn (zerolog.WarnLevel, 2)
+// info (zerolog.InfoLevel, 1)
+// debug (zerolog.DebugLevel, 0)
+// trace (zerolog.TraceLevel, -1)
+func GetLogLevelByString(logLevel string) zerolog.Level {
+
+	level := make(map[string]zerolog.Level)
+	level["trace"] = zerolog.TraceLevel
+	level["debug"] = zerolog.DebugLevel
+	level["info"] = zerolog.InfoLevel
+	level["warning"] = zerolog.WarnLevel
+	level["error"] = zerolog.ErrorLevel
+	level["fatal"] = zerolog.FatalLevel
+	level["panic"] = zerolog.PanicLevel
+
+	return level[logLevel]
+
 }

--- a/pkg/log.go
+++ b/pkg/log.go
@@ -25,8 +25,8 @@ func ZerologSetup(logFile *os.File) zerolog.Logger {
 	// default log level
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
-	return log.Output(zerolog.ConsoleWriter{Out: logFile, NoColor: true}).With().Caller().Logger()
-	//return log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: true}).With().Caller().Logger()
+	return log.Output(zerolog.ConsoleWriter{Out: logFile, NoColor: false}).With().Caller().Logger()
+	//return log.Output(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: false}).With().Caller().Logger()
 }
 
 // GetLogLevelByString receives a log level string, and returns it's related zerolog Level iota

--- a/pkg/log.go
+++ b/pkg/log.go
@@ -1,0 +1,26 @@
+package pkg
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"os"
+	"strconv"
+)
+
+// ZerologSetup setup Zerolog and return the configured Zerolog instance
+func ZerologSetup(logFile *os.File) zerolog.Logger {
+	// short file path/name
+	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
+		short := file
+		for i := len(file) - 1; i > 0; i-- {
+			if file[i] == '/' {
+				short = file[i+1:]
+				break
+			}
+		}
+		file = short
+		return file + ":" + strconv.Itoa(line)
+	}
+
+	return log.Output(zerolog.ConsoleWriter{Out: logFile, NoColor: false}).With().Caller().Logger()
+}

--- a/pkg/ngrok.go
+++ b/pkg/ngrok.go
@@ -3,8 +3,8 @@ package pkg
 import (
 	"context"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"io"
-	"log"
 	"net"
 
 	"github.com/ngrok/ngrok-go"
@@ -16,7 +16,7 @@ import (
 func RunNgrok(ctx context.Context, dest string) {
 	tunnel, err := ngrok.StartTunnel(ctx, config.HTTPEndpoint(), ngrok.WithAuthtokenFromEnv())
 	if err != nil {
-		log.Println(err)
+		log.Error().Err(err).Msg("")
 	}
 
 	fmt.Println("tunnel created: ", tunnel.URL())
@@ -26,14 +26,14 @@ func RunNgrok(ctx context.Context, dest string) {
 	for {
 		conn, err := tunnel.Accept()
 		if err != nil {
-			log.Println(err)
+			log.Error().Err(err).Msg("")
 		}
 
-		log.Println("accepted connection from", conn.RemoteAddr())
+		log.Info().Msgf("accepted connection from %s", conn.RemoteAddr())
 
 		go func() {
 			err := handleConn(ctx, dest, conn)
-			log.Println("connection closed:", err)
+			log.Info().Msgf("connection closed: %s", err)
 		}()
 	}
 }

--- a/pkg/ngrok.go
+++ b/pkg/ngrok.go
@@ -33,7 +33,7 @@ func RunNgrok(ctx context.Context, dest string) {
 
 		go func() {
 			err := handleConn(ctx, dest, conn)
-			log.Info().Msgf("connection closed: %s", err)
+			log.Info().Msgf("connection closed: %v", err)
 		}()
 	}
 }

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,7 +14,7 @@ import (
 func ExecShellReturnStrings(command string, args ...string) (string, string, error) {
 	var outb, errb bytes.Buffer
 	k := exec.Command(command, args...)
-	//  log.Println("Command:", k.String()) //Do not remove this line used for some debugging, will be wrapped by debug log some day.
+	//  log.Info()().Msg()("Command:", k.String()) //Do not remove this line used for some debugging, will be wrapped by debug log some day.
 	k.Stdout = &outb
 	k.Stderr = &errb
 	err := k.Run()
@@ -41,12 +41,12 @@ func ExecShellWithVars(osvars map[string]string, command string, args ...string)
 	cmd := exec.Command(command, args...)
 	cmdReaderOut, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Println(fmt.Sprintf("error: %s failed creating out pipe for: %v", command, err))
+		log.Info().Msg(fmt.Sprintf("error: %s failed creating out pipe for: %v", command, err))
 		return err
 	}
 	cmdReaderErr, err := cmd.StderrPipe()
 	if err != nil {
-		log.Println(fmt.Sprintf("error: %s failed creating out pipe for:  %v", command, err))
+		log.Info().Msg(fmt.Sprintf("error: %s failed creating out pipe for:  %v", command, err))
 		return err
 	}
 
@@ -61,20 +61,20 @@ func ExecShellWithVars(osvars map[string]string, command string, args ...string)
 	doneErr := make(chan bool)
 	go func() {
 		for msg := range stdOut {
-			log.Println("OUT: ", msg)
+			log.Info().Msgf("OUT: %s", msg)
 		}
 		doneOut <- true
 	}()
 	go func() {
 		for msg := range stdErr {
-			log.Println("ERR: ", msg)
+			log.Info().Msgf("ERR: %s", msg)
 		}
 		doneErr <- true
 	}()
 
 	err = cmd.Run()
 	if err != nil {
-		log.Println(fmt.Sprintf("error: %s failed %v", command, err))
+		log.Info().Msg(fmt.Sprintf("error: %s failed %v", command, err))
 		return err
 	} else {
 		close(stdOut)
@@ -90,7 +90,7 @@ func ExecShellWithVars(osvars map[string]string, command string, args ...string)
 func reader(scanner *bufio.Scanner, out chan string) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Println("Error processing logs from command. Error:\n", r)
+			log.Info().Msgf("Error processing logs from command. Error: %s", r)
 		}
 	}()
 	for scanner.Scan() {

--- a/pkg/shell.go
+++ b/pkg/shell.go
@@ -19,11 +19,11 @@ func ExecShellReturnStrings(command string, args ...string) (string, string, err
 	k.Stderr = &errb
 	err := k.Run()
 	if err != nil {
-		log.Printf("Error executing command: %v\n", err)
+		log.Info().Msgf("Error executing command: %v", err)
 	}
-	log.Printf("Command Execution: %s\n", command)
-	log.Printf("OUT: %s\n", outb.String())
-	log.Printf("ERR: %s\n", errb.String())
+	log.Info().Msgf("Command Execution: %s", command)
+	log.Info().Msgf("OUT: %s", outb.String())
+	log.Info().Msgf("ERR: %s", errb.String())
 	return outb.String(), errb.String(), err
 }
 
@@ -32,11 +32,11 @@ func ExecShellReturnStrings(command string, args ...string) (string, string, err
 //   - Map of Vars loaded
 func ExecShellWithVars(osvars map[string]string, command string, args ...string) error {
 
-	log.Printf("INFO: Running %s", command)
+	log.Info().Msgf("INFO: Running %s", command)
 	for k, v := range osvars {
 		os.Setenv(k, v)
 		suppressedValue := strings.Repeat("*", len(v))
-		log.Printf(" export %s = %s", k, suppressedValue)
+		log.Info().Msgf(" export %s = %s", k, suppressedValue)
 	}
 	cmd := exec.Command(command, args...)
 	cmdReaderOut, err := cmd.StdoutPipe()


### PR DESCRIPTION
this PR introduce log level and update current Go standard log.

It uses [zerolog](https://github.com/rs/zerolog), a simple usage example is:

```go
log.Info().Msg("hello world")
```

To make a first simple PR, this PR adds only `debug, info and panic` levels, `debug` is the default level.

Zerolog provides many other nice features as hooks, chains and log context.

This log implementation is working together with the Go standard log library to avoid changing too much files at this point.

The log level is implemented for `local` command only for the time being, and local can be called with:
```go
go run . local --log-level info
```

closes #756 