### PR TITLE
fix: destroy elb

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kubefirst/kubefirst/configs"
+	"github.com/kubefirst/kubefirst/internal/aws"
 	"github.com/kubefirst/kubefirst/internal/domain"
 	"github.com/kubefirst/kubefirst/internal/handlers"
 	"github.com/kubefirst/kubefirst/internal/services"
@@ -202,6 +203,13 @@ cluster provisioning process spinning up the services, and validates the livenes
 		}
 
 		if viper.GetString("cloud") == flagset.CloudAws {
+			//POST-install aws cloud census
+			elbName, sg := aws.GetELBByClusterName(viper.GetString("cluster-name"))
+			viper.Set("aws.vpcid", aws.GetVPCIdByClusterName(viper.GetString("cluster-name")))
+			viper.Set("aws.elb.name", elbName)
+			viper.Set("aws.elb.sg", sg)
+			viper.WriteConfig()
+
 			err = state.UploadKubefirstToStateStore(globalFlags.DryRun)
 			if err != nil {
 				log.Println(err)

--- a/internal/k8s/kubernetes.go
+++ b/internal/k8s/kubernetes.go
@@ -467,9 +467,10 @@ func GetIngressHost(k8sClient *kubernetes.Clientset, namespace string, name stri
 	}
 
 	if ingress != nil {
-		ingressLB := ingress.Status.LoadBalancer.Ingress[0]
-		return ingressLB.Hostname
-
+		if len(ingress.Status.LoadBalancer.Ingress) > 0 {
+			ingressLB := ingress.Status.LoadBalancer.Ingress[0]
+			return ingressLB.Hostname
+		}
 	}
 	return ""
 }

--- a/internal/k8s/kubernetes.go
+++ b/internal/k8s/kubernetes.go
@@ -458,3 +458,18 @@ func SetArgocdCreds(dryRun bool) {
 	viper.Set("argocd.admin.username", "admin")
 	viper.WriteConfig()
 }
+
+func GetIngressHost(k8sClient *kubernetes.Clientset, namespace string, name string) string {
+
+	ingress, err := k8sClient.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, metaV1.GetOptions{})
+	if err != nil {
+		log.Println(fmt.Sprintf("error getting key: %s from ingress: %s", namespace, name), err)
+	}
+
+	if ingress != nil {
+		ingressLB := ingress.Status.LoadBalancer.Ingress[0]
+		return ingressLB.Hostname
+
+	}
+	return ""
+}

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -197,9 +197,9 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 			envs["TF_VAR_instance_type"] = "t4g.medium"
 		}
 
-		clientset, err := k8s.GetClientSet(false)
+		clientset, err := k8s.GetClientSet(skipBaseTerraform)
 		if err != nil {
-			log.Panic(err.Error())
+			log.Panicf("Failed to get kubectl client: %v", err)
 		}
 		host := k8s.GetIngressHost(clientset, "argocd", "argocd-server")
 		elb, security_group, _ := aws.GetELBDetails(host)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -210,7 +210,7 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		}
 		err = aws.DestroySecurityGroupNyName(security_group)
 		if err != nil {
-			log.Panicf("Failed to destroy load balancer: %v", err)
+			log.Panicf("Failed to destroy load balancer security group: %v", err)
 		}
 
 		time.Sleep(45 * time.Second)

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -208,10 +208,13 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		if err != nil {
 			log.Panicf("Failed to destroy load balancer: %v", err)
 		}
-		err = aws.DestroySecurityGroupNyName(security_group)
-		if err != nil {
-			log.Panicf("Failed to destroy load balancer security group: %v", err)
-		}
+		/*
+			Removed for now, to be fixed later.
+			err = aws.DestroySecurityGroupNyName(security_group)
+			if err != nil {
+				log.Panicf("Failed to destroy load balancer security group: %v", err)
+			}
+		*/
 
 		time.Sleep(45 * time.Second)
 		err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "init")

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -203,6 +203,8 @@ func DestroyBaseTerraform(skipBaseTerraform bool) {
 		}
 		host := k8s.GetIngressHost(clientset, "argocd", "argocd-server")
 		elb, security_group, _ := aws.GetELBDetails(host)
+		log.Println("ELB in use:", elb)
+		log.Println("Security Group in use:", security_group)
 
 		err = aws.DestroyLoadBalancerByName(elb)
 		if err != nil {


### PR DESCRIPTION
Major change:
- https://github.com/kubefirst/kubefirst/issues/804
- Add some AWS cloud info after install is completed, informations such as: vpcId, ELB Name and ELB SG. 
- Replace the way destroy removes ELB and its SG


Signed-off-by: 6za <53096417+6za@users.noreply.github.com>