### PR TITLE
feat: add redirect to https from ingress

### DIFF
--- a/cmd/local/postrun.go
+++ b/cmd/local/postrun.go
@@ -1,15 +1,13 @@
 package local
 
 import (
-	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 
-	"github.com/kubefirst/kubefirst/configs"
-	"github.com/kubefirst/kubefirst/internal/k8s"
+	"github.com/rs/zerolog/log"
+
 	"github.com/kubefirst/kubefirst/internal/reports"
 	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/cobra"
@@ -21,14 +19,6 @@ func runPostLocal(cmd *cobra.Command, args []string) error {
 		log.Info().Msg("not calling console, console flag is disabled")
 		return nil
 	}
-
-	config := configs.ReadConfig()
-
-	log.Info().Msg("storing certificates into application secrets namespace")
-	if err := k8s.CreateSecretsFromCertificatesForLocalWrapper(config); err != nil {
-		log.Error().Err(err).Msg("")
-	}
-	log.Info().Msg("storing certificates into application secrets namespace done")
 
 	log.Info().Msg("Starting the presentation of console and api for the handoff screen")
 
@@ -44,10 +34,6 @@ func runPostLocal(cmd *cobra.Command, args []string) error {
 	reports.LocalHandoffScreen(dryRun, silentMode)
 
 	log.Info().Msgf("Kubefirst Console available at: http://localhost:9094", silentMode)
-	_, _, err = pkg.ExecShellReturnStrings(config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "-n", "argocd", "apply", "-f", fmt.Sprintf("%s/gitops/ingressroute.yaml", config.K1FolderPath))
-	if err != nil {
-		log.Printf("failed to create ingress route to argocd: %s", err)
-	}
 
 	log.Info().Msgf("Kubefirst Console available at: http://localhost:9094", silentMode)
 

--- a/cmd/local/prerun.go
+++ b/cmd/local/prerun.go
@@ -3,6 +3,9 @@ package local
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/dustin/go-humanize"
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/addon"
@@ -18,8 +21,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"net/http"
-	"time"
 )
 
 func validateLocal(cmd *cobra.Command, args []string) error {
@@ -71,7 +72,7 @@ func validateLocal(cmd *cobra.Command, args []string) error {
 	viper.Set("adminemail", adminEmail)
 
 	viper.Set("argocd.local.service", pkg.ArgoCDLocalURL)
-	viper.Set("vault.local.service", pkg.VaultLocalURL)
+	viper.Set("vault.local.service", pkg.VaultLocalURLTLS)
 	go pkg.RunNgrok(context.TODO())
 
 	// addons

--- a/configs/config.go
+++ b/configs/config.go
@@ -34,9 +34,9 @@ type Config struct {
 	KubectlClientPath       string
 	KubeConfigPath          string
 	KubeConfigFolder        string
-	HelmClientPath      string
-	GitOpsLocalRepoPath string
-	NgrokVersion        string
+	HelmClientPath          string
+	GitOpsLocalRepoPath     string
+	NgrokVersion            string
 	NgrokClientPath         string
 	TerraformClientPath     string
 	K3dPath                 string
@@ -136,7 +136,7 @@ func ReadConfig() *Config {
 	config.GitopsTemplateURL = "https://github.com/kubefirst/gitops-template-gh.git"
 	// Local Configs URL
 	config.LocalArgoWorkflowsURL = "http://argo.localdev.me"
-	config.LocalVaultURL = "http://vault.localdev.me"
+	config.LocalVaultURL = "https://vault.localdev.me"
 	config.LocalArgoURL = "http://argocd.localdev.me"
 	config.LocalAtlantisURL = "http://atlantis.localdev.me"
 	config.LocalChartmuseumURL = "http://localhost:8181"

--- a/internal/argocd/argocd.go
+++ b/internal/argocd/argocd.go
@@ -45,9 +45,8 @@ type Config struct {
 		Ingress   struct {
 			Enabled     string `yaml:"enabled"`
 			Annotations struct {
-				IngressKubernetesIoRewriteTarget      string `yaml:"ingress.kubernetes.io/rewrite-target"`
-				IngressKubernetesIoBackendProtocol    string `yaml:"ingress.kubernetes.io/backend-protocol"`
-				IngressKubernetesIoActionsSslRedirect string `yaml:"ingress.kubernetes.io/actions.ssl-redirect"`
+				IngressKubernetesIoRewriteTarget   string `yaml:"ingress.kubernetes.io/rewrite-target"`
+				IngressKubernetesIoBackendProtocol string `yaml:"ingress.kubernetes.io/backend-protocol"`
 			} `yaml:"annotations"`
 			Hosts []string    `yaml:"hosts"`
 			TLS   []TLSConfig `yaml:"tls"`
@@ -467,7 +466,6 @@ func GetArgoCDInitialLocalConfig(gitOpsRepo string, botPrivateKey string) Config
 	argoCDConfig.Server.Ingress.Enabled = "true"
 	argoCDConfig.Server.Ingress.Annotations.IngressKubernetesIoRewriteTarget = "/"
 	argoCDConfig.Server.Ingress.Annotations.IngressKubernetesIoBackendProtocol = "HTTPS"
-	argoCDConfig.Server.Ingress.Annotations.IngressKubernetesIoActionsSslRedirect = `{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}`
 	argoCDConfig.Server.Ingress.Hosts = []string{"argocd.localdev.me"}
 
 	argoCDConfig.Server.Ingress.TLS = []TLSConfig{

--- a/internal/k3d/secrets.go
+++ b/internal/k3d/secrets.go
@@ -5,8 +5,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/spf13/viper"
@@ -17,7 +18,7 @@ import (
 func AddK3DSecrets(dryrun bool) error {
 	clientset, err := k8s.GetClientSet(dryrun)
 
-	newNamespaces := []string{"argo", "argocd", "atlantis", "chartmuseum", "github-runner", "vault", "development", "staging", "production"}
+	newNamespaces := []string{"argo", "argocd", "atlantis", "chartmuseum", "github-runner", "vault", "development", "staging", "production", "kubefirst", "minio"}
 	for i, s := range newNamespaces {
 		namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: s}}
 		_, err = clientset.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})

--- a/internal/k8s/kubernetes.go
+++ b/internal/k8s/kubernetes.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"io"
-	v1 "k8s.io/api/core/v1"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/itchyny/gojq"
 	"github.com/kubefirst/kubefirst/configs"
@@ -386,7 +387,7 @@ func LoopUntilPodIsReady(dryRun bool) {
 	if len(token) == 0 {
 
 		totalAttempts := 50
-		url := pkg.VaultLocalURL + "/v1/sys/health"
+		url := pkg.VaultLocalURLTLS + "/v1/sys/health"
 		for i := 0; i < totalAttempts; i++ {
 			log.Info().Msgf("vault is not ready yet, sleeping and checking again, attempt (%d/%d)", i+1, totalAttempts)
 			time.Sleep(10 * time.Second)


### PR DESCRIPTION
- Change gitops-branch to add-ingress-localhost
- Remove certificate secret creation from postrun and move it to local.go
- Move the installation of argocd ingressroute.yaml to local.go and create a new ingress to force redirect connections from argocd to https
- Fix vault endpoint to use https instead of http
- Force creation of kubefirst and minio namespaces at start of installation, thus allowing certificate secrets to be created at beginning
- Remove some unnecessary annotations from argocd ingress
