### PR TITLE
fix: Create new terraform output variable

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -160,18 +160,17 @@ func ApplyBaseTerraform(dryRun bool, directory string) {
 		log.Println("keyid is:", keyId)
 		viper.Set("vault.kmskeyid", keyId)
 
+		var terraformNodeArnOutput bytes.Buffer
 		k = exec.Command(config.TerraformClientPath, "output", "eks_node_role_arn")
-		k.Stdout = &terraformOutput
+		k.Stdout = &terraformNodeArnOutput
 		k.Stderr = os.Stderr
 		errKey = k.Run()
 		if errKey != nil {
 			log.Panicf("error: terraform output failed %v", errKey)
 		}
 		os.RemoveAll(fmt.Sprintf("%s/.terraform", directory))
-		nodeGroupArn := strings.TrimSpace(terraformOutput.String())
+		nodeGroupArn := strings.TrimSpace(terraformNodeArnOutput.String())
 		nodeGroupArn = nodeGroupArn[1 : len(nodeGroupArn)-1]
-		log.Println("nodeGroupArn is:", nodeGroupArn)
-		viper.Set("aws.node-group-arn", nodeGroupArn)
 		viper.Set("create.terraformapplied.base", true)
 		viper.WriteConfig()
 		pkg.Detokenize(fmt.Sprintf("%s/gitops", config.K1FolderPath))


### PR DESCRIPTION
Due the use of the same variable of Terraform Output for KeyID and KMS ARN, there's garbage from keyId loading with KMS ARN. Made new variable to store KMS ANS.

Signed-off-by: Jessica Marinho <jessica@kubeshop.io>