### PR TITLE
added validation on bot password when is gitlab flavor

### DIFF
--- a/internal/flagset/installer.go
+++ b/internal/flagset/installer.go
@@ -2,8 +2,9 @@ package flagset
 
 import (
 	"errors"
-	"github.com/kubefirst/kubefirst/pkg"
 	"log"
+
+	"github.com/kubefirst/kubefirst/pkg"
 
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/addon"
@@ -224,5 +225,11 @@ func validateInstallationFlags() error {
 		log.Println(message)
 		return errors.New(message)
 	}
+
+	if len(viper.GetString("botpassword")) < 8 || (viper.GetString("gitprovider") == "gitlab") {
+		msg := "BotPassword (to GitLab flavor) is too short (minimum is 8 characters)"
+		return errors.New(msg)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Added validation on init cmd regarding the length of the bot's password to avoid the terraform error on the installation's last steps.

fix #898 