### PR TITLE
fix: ui cli issues

### DIFF
--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -93,16 +93,16 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	progressPrinter.AddTracker("step-github", "Setup gitops on github", 3)
 	progressPrinter.AddTracker("step-base", "Setup base cluster", 2)
 	progressPrinter.AddTracker("step-apps", "Install apps to cluster", 4)
-
-	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), silentMode)
-
+	progressPrinter.AddTracker("step-telemetry", pkg.SendTelemetry, 2)
 	if useTelemetry {
-		progressPrinter.AddTracker("step-telemetry", pkg.SendTelemetry, 2)
 		if err := wrappers.SendSegmentIoTelemetry("", pkg.MetricMgmtClusterInstallStarted); err != nil {
 			log.Error().Err(err).Msg("")
 		}
-		progressPrinter.IncrementTracker("step-telemetry", 1)
+		pkg.InformUser("Telemetry info sent", silentMode)
+	} else {
+		pkg.InformUser("Telemetry skipped by user request", silentMode)
 	}
+	progressPrinter.IncrementTracker("step-telemetry", 1)
 
 	// todo need to add go channel to control when ngrok should close
 	// and use context to handle closing the open goroutine/connection
@@ -330,7 +330,6 @@ func runLocal(cmd *cobra.Command, args []string) error {
 
 	// TODO: K3D =>  NEED TO REMOVE local-backend.tf and rename remote-backend.md
 
-	pkg.InformUser("Welcome to local kubefirst experience", silentMode)
 	pkg.InformUser("To use your cluster port-forward - argocd", silentMode)
 	pkg.InformUser("If not automatically injected, your kubeconfig is at:", silentMode)
 	pkg.InformUser("k3d kubeconfig get "+viper.GetString("cluster-name"), silentMode)
@@ -420,15 +419,6 @@ func runLocal(cmd *cobra.Command, args []string) error {
 		wg.Done()
 	}()
 
-	log.Info().Msg("sending mgmt cluster install completed metric")
-
-	if useTelemetry {
-		if err = wrappers.SendSegmentIoTelemetry("", pkg.MetricMgmtClusterInstallCompleted); err != nil {
-			log.Error().Err(err).Msg("")
-		}
-		progressPrinter.IncrementTracker("step-telemetry", 1)
-	}
-
 	_, _, err = pkg.ExecShellReturnStrings(config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "-n", "argocd", "apply", "-f", fmt.Sprintf("%s/gitops/ingressroute.yaml", config.K1FolderPath))
 
 	if err != nil {
@@ -448,6 +438,18 @@ func runLocal(cmd *cobra.Command, args []string) error {
 
 	// waiting GitHub/atlantis step
 	wg.Wait()
+
+	log.Info().Msg("sending mgmt cluster install completed metric")
+	if useTelemetry {
+		if err = wrappers.SendSegmentIoTelemetry("", pkg.MetricMgmtClusterInstallCompleted); err != nil {
+			log.Error().Err(err).Msg("")
+		}
+		pkg.InformUser("Telemetry info sent", silentMode)
+	} else {
+		pkg.InformUser("Telemetry skipped by user request", silentMode)
+	}
+	progressPrinter.IncrementTracker("step-telemetry", 1)
+
 	pkg.InformUser("Kubefirst installation finished successfully", silentMode)
 	return nil
 

--- a/cmd/local/prerun.go
+++ b/cmd/local/prerun.go
@@ -120,7 +120,8 @@ func validateLocal(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	progressPrinter.SetupProgress(4, silentMode)
+	//progress bars are global, it is not needed to initialized on every stage.
+	progressPrinter.SetupProgress(8, silentMode)
 
 	progressPrinter.AddTracker("step-0", "Process Parameters", 1)
 	progressPrinter.AddTracker("step-download", pkg.DownloadDependencies, 3)

--- a/internal/progressPrinter/progress.go
+++ b/internal/progressPrinter/progress.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/progress"
+	"github.com/rs/zerolog/log"
 )
 
 //ActionTracker Struct used to manage tracker object
@@ -48,7 +49,7 @@ func GetInstance() *progressPrinter {
 // Used for general initialization of tracker object and overall counter
 func SetupProgress(numTrackers int, silentMode bool) {
 	flag.Parse()
-	fmt.Printf("Init actions: %d expected tasks ...\n\n", numTrackers)
+	log.Debug().Msg(fmt.Sprintf("Init actions: %d expected tasks ...\n\n", numTrackers))
 	// if silent mode, dont show progress bar render
 	if silentMode {
 		return


### PR DESCRIPTION
Solves: 
- #919 
- #918 


Sample:
```bash 

./kubefirst local --gitops-branch main --skip-metaphor
2022/12/15 16:49:30 kubefirst started
Logging at: /app/logs/log_1671122970.log
Download dependencies         ... 33.3% [#########...................] [1 in 300.923ms]
Download dependencies         ... done! [3 in 6.305s]
Create SSH keys               ... done! [1 in 6.313s]
Clone and Detokenize (GitOps) ... done! [1 in 7.015s]
- initialization step is done!
Process Parameters            ... done! [1 in 7.242s]
- Telemetry info sent
- Creating github resources with terraform
- Created gitops Repo in github.com/-------
- pushing local detokenized gitops content to new remote github.com/kxdroid
Setup gitops on github        ... done! [3 in 1m4.027s]
- create initial argocd repository
- helm repo add argo https://argoproj.github.io/argo-helm and helm repo update
- helm install argo and wait
- ArgoCD is running, continuing
- Setting argocd username and password credentials
- argocd username and password credentials set successfully
- Getting an argocd auth token
- argocd admin auth token set
- applying the registry application to argocd
- waiting for Vault to be ready...
- configuring vault with terraform
- vault terraform executed successfully
- Vault secret created
- applying users terraform
Setup base cluster            ... done! [2 in 4m17.898s]
Install apps to cluster       ... done! [4 in 4m17.898s]
- executed users terraform successfully
- To use your cluster port-forward - argocd
- If not automatically injected, your kubeconfig is at:
- k3d kubeconfig get kubefirst
- Expose Argo-CD
- kubectl -n argocd port-forward svc/argocd-server 8080:80
- Argo User: admin
- Argo Password: ---------
- Deploying metaphor applications
- waiting "atlantis plan" finish to proceed...
- Kubefirst installation finished successfully
- Kubefirst installation almost finished successfully, please wait final setups steps
Send Telemetry                ... done! [2 in 5m13.472s]
- Telemetry info sent
- Kubefirst installation finished successfully
```
Signed-off-by: 6za <53096417+6za@users.noreply.github.com>