### PR TITLE
fix: Include env var for region

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -24,6 +24,7 @@ func ApplyGitHubTerraform(dryRun bool) {
 	//* https://registry.terraform.io/providers/hashicorp/aws/2.34.0/docs#shared-credentials-file
 	envs := map[string]string{}
 	envs["AWS_SDK_LOAD_CONFIG"] = "1"
+	envs["AWS_REGION"] = viper.GetString("aws.region")
 	aws.ProfileInjection(&envs)
 	// Prepare for terraform gitlab execution
 	envs["GITHUB_TOKEN"] = os.Getenv("KUBEFIRST_GITHUB_AUTH_TOKEN")
@@ -65,6 +66,7 @@ func DestroyGitHubTerraform(dryRun bool) {
 	//* https://registry.terraform.io/providers/hashicorp/aws/2.34.0/docs#shared-credentials-file
 	envs := map[string]string{}
 	envs["AWS_SDK_LOAD_CONFIG"] = "1"
+	envs["AWS_REGION"] = viper.GetString("aws.region")
 	aws.ProfileInjection(&envs)
 	// Prepare for terraform gitlab execution
 	envs["GITHUB_TOKEN"] = os.Getenv("KUBEFIRST_GITHUB_AUTH_TOKEN")

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/aws"
@@ -25,6 +26,7 @@ func terraformConfig(terraformEntryPoint string) map[string]string {
 		envs["AWS_SDK_LOAD_CONFIG"] = "1"
 		aws.ProfileInjection(&envs)
 		envs["TF_VAR_aws_region"] = viper.GetString("aws.region")
+		envs["AWS_REGION"] = viper.GetString("aws.region")
 	}
 
 	switch terraformEntryPoint {


### PR DESCRIPTION
Terraform provider needs to know which region to use to authenticate to AWS, if the region doesn't exist in the AWS shared file, it must be informed in another way.

An alternative is to include the region informed by the installer flag as an AWS_REGION environment variable, on this way terraform provider will be able to identify the correct version through the flag.


Signed-off-by: Jessica Marinho <jessica@kubeshop.io>