### PR TITLE
fix: #867 ensure SSH key is removed post-destroy

### DIFF
--- a/cmd/destroyAwsGithub.go
+++ b/cmd/destroyAwsGithub.go
@@ -201,7 +201,8 @@ var destroyAwsGithubCmd = &cobra.Command{
 		fmt.Println("End of execution destroy")
 		time.Sleep(time.Millisecond * 100)
 
-		log.Println(destroyFlags, config)
+		// Please, don't do this, this leaks credentials.
+		// log.Println(destroyFlags, config)
 		return nil
 	},
 }

--- a/cmd/destroyAwsGithub.go
+++ b/cmd/destroyAwsGithub.go
@@ -17,11 +17,13 @@ import (
 	"github.com/kubefirst/kubefirst/internal/argocd"
 	"github.com/kubefirst/kubefirst/internal/flagset"
 	"github.com/kubefirst/kubefirst/internal/gitClient"
+	"github.com/kubefirst/kubefirst/internal/githubWrapper"
 	"github.com/kubefirst/kubefirst/internal/handlers"
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 	"github.com/kubefirst/kubefirst/internal/services"
 	"github.com/kubefirst/kubefirst/internal/terraform"
+	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -149,14 +151,32 @@ var destroyAwsGithubCmd = &cobra.Command{
 		progressPrinter.IncrementTracker("step-destroy", 1)
 
 		if !destroyFlags.SkipGithubTerraform {
+			gitHubClient := githubWrapper.New()
 			githubTfApplied := viper.GetBool("terraform.github.apply.complete")
 			if githubTfApplied {
 				informUser("terraform destroying github resources", globalFlags.SilentMode)
 				tfEntrypoint := config.GitOpsRepoPath + "/terraform/github"
-				terraform.InitDestroyAutoApprove(globalFlags.DryRun, tfEntrypoint)
-				informUser("successfully destroyed github resources", globalFlags.SilentMode)
+				forceDestroy := false
+				err := terraform.InitAndReconfigureActionAutoApprove(globalFlags.DryRun, "destroy", tfEntrypoint)
+				if err != nil {
+					forceDestroy = true
+					informUser("unable to destroy via terraform", globalFlags.SilentMode)
+				} else {
+					informUser("successfully destroyed github resources", globalFlags.SilentMode)
+				}
+				if forceDestroy {
+					informUser("running force destroy...", globalFlags.SilentMode)
+					err = pkg.ForceGithubDestroyCloud(gitHubClient)
+					if err != nil {
+						return err
+					}
+					informUser("force destroy, done", globalFlags.SilentMode)
+				}
+				//Best-effort basis, if terraform does its task, I believe it removes already.
+				_ = pkg.GithubRemoveSSHKeys(gitHubClient)
 			}
 			log.Println("github terraform destruction complete")
+
 		}
 		progressPrinter.IncrementTracker("step-destroy", 1)
 

--- a/cmd/githubAdd.go
+++ b/cmd/githubAdd.go
@@ -31,7 +31,7 @@ var githubAddCmd = &cobra.Command{
 		}
 
 		log.Debug().Msgf("Org used: %s", viper.GetString("github.owner"))
-		log.Debug().Msgf("dry-run: %s", globalFlags.DryRun)
+		log.Debug().Msgf("dry-run: %t", globalFlags.DryRun)
 
 		if !viper.GetBool("github.terraformapplied.gitops") {
 

--- a/cmd/githubAdd.go
+++ b/cmd/githubAdd.go
@@ -31,7 +31,7 @@ var githubAddCmd = &cobra.Command{
 		}
 
 		log.Debug().Msgf("Org used: %s", viper.GetString("github.owner"))
-		log.Debug().Msgf("dry-run:", globalFlags.DryRun)
+		log.Debug().Msgf("dry-run: %s", globalFlags.DryRun)
 
 		if !viper.GetBool("github.terraformapplied.gitops") {
 

--- a/cmd/githubAdd.go
+++ b/cmd/githubAdd.go
@@ -4,7 +4,7 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"log"
+	"github.com/rs/zerolog/log"
 
 	"github.com/kubefirst/kubefirst/internal/flagset"
 	"github.com/kubefirst/kubefirst/internal/github"
@@ -26,12 +26,12 @@ var githubAddCmd = &cobra.Command{
 		}
 
 		if globalFlags.DryRun {
-			log.Printf("[#99] Dry-run mode, githubAddCmd skipped.")
+			log.Info().Msg("[#99] Dry-run mode, githubAddCmd skipped.")
 			return nil
 		}
 
-		log.Println("Org used:", viper.GetString("github.owner"))
-		log.Println("dry-run:", globalFlags.DryRun)
+		log.Debug().Msgf("Org used: %s", viper.GetString("github.owner"))
+		log.Debug().Msgf("dry-run:", globalFlags.DryRun)
 
 		if !viper.GetBool("github.terraformapplied.gitops") {
 
@@ -44,7 +44,7 @@ var githubAddCmd = &cobra.Command{
 			progressPrinter.IncrementTracker("step-github", 1)
 		}
 
-		log.Printf("GitHub terraform Executed and uploaded ssh key to user with Success")
+		log.Info().Msg("GitHub terraform Executed and uploaded ssh key to user with Success")
 		return nil
 	},
 }

--- a/cmd/k1Ready.go
+++ b/cmd/k1Ready.go
@@ -72,9 +72,9 @@ var k1ReadyCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			log.Info().Msgf("App % is synched: %t", app, isAppSynched)
+			log.Info().Msgf("App %s is synched: %t", app, isAppSynched)
 			if !isAppSynched {
-				log.Warn().Msgf("App %s is is not ready, synch status: %s ", app, isAppSynched)
+				log.Warn().Msgf("App %s is is not ready, synch status: %t ", app, isAppSynched)
 				return fmt.Errorf("app %s is is not ready, synch status: %v", app, isAppSynched)
 			}
 		}

--- a/cmd/k1Ready.go
+++ b/cmd/k1Ready.go
@@ -6,10 +6,11 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/argocd"
@@ -44,20 +45,20 @@ var k1ReadyCmd = &cobra.Command{
 		portForwardArgocd, err := k8s.PortForward(globalFlags.DryRun, "argocd", "svc/argocd-server", "8080:80")
 		defer func() {
 			if portForwardArgocd != nil {
-				log.Println("Closed argoCD port forward")
+				log.Info().Msg("Closed argoCD port forward")
 				_ = portForwardArgocd.Process.Signal(syscall.SIGTERM)
 			}
 		}()
 		if err != nil {
 			//Port-forwarding may be already in play, if fails next commands will detect and fail as expected.
-			log.Println("Error forwarding ports")
+			log.Warn().Msg("Error forwarding ports")
 
 		}
 		if globalFlags.DryRun {
 			log.Printf("[#99] Dry-run mode, k1ReadyCmd skipped.")
 			return nil
 		}
-		log.Println("argo forwarded called")
+		log.Info().Msg("argo forwarded called")
 		argoCDUsername := viper.GetString("argocd.admin.username")
 		argoCDPassword := viper.GetString("argocd.admin.password")
 		token, err := argocd.GetArgoCDToken(argoCDUsername, argoCDPassword)
@@ -71,9 +72,9 @@ var k1ReadyCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			log.Println("App", app, "is synched:", isAppSynched)
+			log.Info().Msgf("App % is synched: %t", app, isAppSynched)
 			if !isAppSynched {
-				log.Println("App", app, "is is not ready, synch status:", isAppSynched)
+				log.Warn().Msgf("App %s is is not ready, synch status: %s ", app, isAppSynched)
 				return fmt.Errorf("app %s is is not ready, synch status: %v", app, isAppSynched)
 			}
 		}
@@ -81,28 +82,28 @@ var k1ReadyCmd = &cobra.Command{
 		//Check cluster: To collect extra info from the cluster
 		//To confirm if cluster is in ready state or some node is not there yet.
 		stateOfNodesOut, stateOfNodesErr, err := pkg.ExecShellReturnStrings(config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "-n", "kube-system", "get", "ds", "kube-proxy")
-		log.Printf("Result:\n\t%s\n\t%s\n", stateOfNodesOut, stateOfNodesErr)
+		log.Info().Msgf("Result:\n\t%s\n\t%s\n", stateOfNodesOut, stateOfNodesErr)
 		if err != nil {
-			log.Printf("error: failed to get state of cluster %s", err)
+			log.Warn().Msgf("error: failed to get state of cluster %s", err)
 		}
 		stateOfNodesOut, stateOfNodesErr, err = pkg.ExecShellReturnStrings(config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "-n", "kube-system", "get", "ds", "aws-node")
-		log.Printf("Result:\n\t%s\n\t%s\n", stateOfNodesOut, stateOfNodesErr)
+		log.Info().Msgf("Result:\n\t%s\n\t%s\n", stateOfNodesOut, stateOfNodesErr)
 		if err != nil {
-			log.Printf("error: failed to get state of cluster %s", err)
+			log.Warn().Msgf("error: failed to get state of cluster %s", err)
 		}
 		stateOfNodesOut, stateOfNodesErr, err = pkg.ExecShellReturnStrings(config.KubectlClientPath, "--kubeconfig", config.KubeConfigPath, "get", "nodes")
-		log.Printf("Result:\n\t%s\n\t%s\n", stateOfNodesOut, stateOfNodesErr)
+		log.Info().Msgf("Result:\n\t%s\n\t%s\n", stateOfNodesOut, stateOfNodesErr)
 		if err != nil {
-			log.Printf("error: failed to get state of cluster %s", err)
+			log.Warn().Msgf("error: failed to get state of cluster %s", err)
 		}
 
 		//Check chartMuseum repository
 		// issue: 386
 		for i := 0; i < 30; i++ {
 			isCMReady, err := chartMuseum.IsChartMuseumReady()
-			log.Printf("Checking status of chartMuseum: %v", isCMReady)
+			log.Info().Msgf("Checking status of chartMuseum: %v", isCMReady)
 			if err == nil && isCMReady {
-				log.Printf("chartMuseum is Ready - 30 secs grace period")
+				log.Warn().Msgf("chartMuseum is Ready - 30 secs grace period")
 				time.Sleep(30 * time.Second)
 				return nil
 			}

--- a/cmd/local/destroy.go
+++ b/cmd/local/destroy.go
@@ -2,6 +2,8 @@ package local
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/githubWrapper"
 	"github.com/kubefirst/kubefirst/internal/k3d"
@@ -10,7 +12,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"time"
 )
 
 func NewDestroyCommand() *cobra.Command {

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -436,8 +436,6 @@ func runLocal(cmd *cobra.Command, args []string) error {
 		log.Error().Err(err).Msgf("failed to delete argocd primary ingress route: %s", err)
 	}
 
-	log.Info().Msg("Kubefirst installation finished successfully")
-	pkg.InformUser("Kubefirst installation finished successfully", silentMode)
 	log.Info().Msg("Kubefirst installation almost finished successfully, please wait final setups steps")
 	pkg.InformUser("Kubefirst installation almost finished successfully, please wait final setups steps", silentMode)
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2,8 +2,9 @@ package github
 
 import (
 	"fmt"
-	"log"
 	"os"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/aws"
@@ -15,9 +16,9 @@ func ApplyGitHubTerraform(dryRun bool) {
 
 	config := configs.ReadConfig()
 
-	log.Println("Executing ApplyGithubTerraform")
+	log.Info().Msg("Executing ApplyGithubTerraform")
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, ApplyGithubTerraform skipped.")
+		log.Info().Msg("[#99] Dry-run mode, ApplyGithubTerraform skipped.")
 		return
 	}
 	//* AWS_SDK_LOAD_CONFIG=1
@@ -36,16 +37,16 @@ func ApplyGitHubTerraform(dryRun bool) {
 
 	err := os.Chdir(directory)
 	if err != nil {
-		log.Panic("error: could not change directory to " + directory)
+		log.Panic().Msgf("error: could not change directory to %s", directory)
 	}
 	err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "init")
 	if err != nil {
-		log.Panicf("error: terraform init for github failed %s", err)
+		log.Panic().Msgf("error: terraform init for github failed %s", err)
 	}
 
 	err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "apply", "-auto-approve")
 	if err != nil {
-		log.Panicf("error: terraform apply for github failed %s", err)
+		log.Panic().Msgf("error: terraform apply for github failed %s", err)
 	}
 	os.RemoveAll(fmt.Sprintf("%s/.terraform", directory))
 	viper.Set("github.terraformapplied.gitops", true)
@@ -57,9 +58,9 @@ func DestroyGitHubTerraform(dryRun bool) {
 
 	config := configs.ReadConfig()
 
-	log.Println("Executing DestroyGitHubTerraform")
+	log.Info().Msg("Executing DestroyGitHubTerraform")
 	if dryRun {
-		log.Printf("[#99] Dry-run mode, DestroyGitHubTerraform skipped.")
+		log.Info().Msg("[#99] Dry-run mode, DestroyGitHubTerraform skipped.")
 		return
 	}
 	//* AWS_SDK_LOAD_CONFIG=1
@@ -77,16 +78,16 @@ func DestroyGitHubTerraform(dryRun bool) {
 	directory := fmt.Sprintf("%s/gitops/terraform/github", config.K1FolderPath)
 	err := os.Chdir(directory)
 	if err != nil {
-		log.Panic("error: could not change directory to " + directory)
+		log.Panic().Msgf("error: could not change directory to %s", directory)
 	}
 	err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "init")
 	if err != nil {
-		log.Panicf("error: terraform init for github failed %s", err)
+		log.Panic().Msgf("error: terraform init for github failed %s", err)
 	}
 
 	err = pkg.ExecShellWithVars(envs, config.TerraformClientPath, "destroy", "-auto-approve")
 	if err != nil {
-		log.Panicf("error: terraform destroy for github failed %s", err)
+		log.Panic().Msgf("error: terraform destroy for github failed %s", err)
 	}
 	os.RemoveAll(fmt.Sprintf("%s/.terraform", directory))
 	viper.Set("github.terraformapplied.gitops", true)

--- a/pkg/destroy.go
+++ b/pkg/destroy.go
@@ -20,18 +20,6 @@ func ForceLocalDestroy(gitHubClient githubWrapper.GithubSession) error {
 	if err != nil && resp.StatusCode != http.StatusNotFound {
 		return err
 	}
-	//TODO: Remove this block after metaphor slim migration
-	resp, err = gitHubClient.RemoveRepo(owner, "metaphor")
-	if err != nil && resp.StatusCode != http.StatusNotFound {
-		return err
-	}
-
-	//TODO: Remove this block after metaphor slim migration
-	resp, err = gitHubClient.RemoveRepo(owner, "metaphor-go")
-	if err != nil && resp.StatusCode != http.StatusNotFound {
-		return err
-	}
-	//TODO: confirm this is the metpahor-slim for local
 	resp, err = gitHubClient.RemoveRepo(owner, "metaphor-frontend")
 	if err != nil && resp.StatusCode != http.StatusNotFound {
 		return err


### PR DESCRIPTION
Fix: 
- #867 

Mitigates: 
- #896


The core change is here: 
https://github.com/kubefirst/kubefirst/compare/upd_destroy_clouds_221220?expand=1#diff-d39c1b78ba45da9a30e27d6d6e428e16a69ffb2661cfb4a99e0db3fe63f955d9R159-R176

- reuse of local destroy mode to `aws-github`

Signed-off-by: 6za <53096417+6za@users.noreply.github.com>