### PR TITLE
fix: #974

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,8 @@ builds:
       - linux
       - darwin
 #      - windows
+    flags:
+      - -trimpath
     ldflags:
       - -X github.com/kubefirst/kubefirst/configs.K1Version={{.Version}}
       

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -70,7 +70,7 @@ func NewCommand() *cobra.Command {
 	localCmd.Flags().StringVar(
 		&logLevel,
 		"log-level",
-		"debug",
+		"info",
 		"available log levels are: trace, debug, info, warning, error, fatal, panic",
 	)
 


### PR DESCRIPTION
fix: 
- #974 

Updates go-releaser to make logs look nicer:

Before:
```bash 
2022-12-21T19:36 DBG ../../../../../../../app/pkg/shell.go:26 > ERR:
2022-12-21T19:36 ERR ../../../../../../../app/cmd/local/postrun.go:31 > error="exec: \"xdg-open\": executable file not found in $PATH"
2022-12-21T19:36 INF ../../../../../../../app/pkg/ngrok.go:45 > accepted connection from 140.82.115.106:18041
2022-12-21T19:37 INF ../../../../../../../app/cmd/local/postrun.go:36 > Kubefirst Console available at: https://kubefirst.localdev.me
```

After: 
```bash 
2022-12-21T20:02 INF github.com/kubefirst/kubefirst/pkg/helpers.go:619 > k3d cluster deleted
2022-12-21T20:02 INF github.com/kubefirst/kubefirst/pkg/helpers.go:619 > be sure to run `kubefirst clean` before your next cloud provision
2022-12-21T20:02 INF github.com/kubefirst/kubefirst/cmd/local/destroy.go:81 > end of execution destroy
```

Details: 
https://carlosbecker.com/posts/goreleaser-reproducible-buids/
https://stackoverflow.com/questions/63831540/removing-module-path-in-trace-in-go

Signed-off-by: 6za <53096417+6za@users.noreply.github.com>