### PR TITLE
feat: format log information

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/kubefirst/kubefirst/internal/reports"
 	stdLog "log"
 	"os"
 	"time"
@@ -31,10 +32,10 @@ func main() {
 	_ = os.Mkdir(logsFolder, 0700)
 
 	logfile := fmt.Sprintf("%s/log_%d.log", logsFolder, epoch)
-	//fmt.Printf("Logging at: %s \n", logfile)
-	fmt.Printf("\n-----------\n")
-	fmt.Printf("Follow your logs with: \n   tail -f  %s \n", logfile)
-	fmt.Printf("\n-----------\n")
+
+	msg := fmt.Sprintf("Follow your logs with: tail -f %s", logfile)
+	fmt.Println(reports.StyleMessage(msg))
+
 	file, err := pkg.OpenLogFile(logfile)
 	if err != nil {
 		stdLog.Panicf("unable to store log location, error is: %s", err)


### PR DESCRIPTION
before:
<img width="653" alt="Screenshot 2023-01-05 at 10 53 25" src="https://user-images.githubusercontent.com/188671/210796332-e865bc9d-f0ff-4adb-bad6-de5a7e4e33d7.png">

after:
<img width="604" alt="Screenshot 2023-01-05 at 10 53 03" src="https://user-images.githubusercontent.com/188671/210796388-6e219c5c-2e1f-49fd-bdf8-b98e176296d0.png">


Signed-off-by: João Vanzuita <joao@kubeshop.io>