### PR TITLE
revert main color scheme, except for the links in the pages

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,5 +1,5 @@
 :root > * {
-  --md-primary-fg-color:        #8851C8;
+  --md-primary-fg-color:        #3C356C;
   --md-primary-fg-color--light: #DF6D5D;
   --md-primary-fg-color--dark:  #81E2B4;
 }
@@ -14,4 +14,8 @@
 
 [dir=ltr] .md-typeset ol, [dir=ltr] .md-typeset ul {
   padding-left: 1.25em;
+}
+
+.md-typeset a {
+  color: #8851C8 !important;
 }


### PR DESCRIPTION
the original color contrast isn't accessible for people with impart vision and people with monochromacy

Signed-off-by: Frédéric Harper <hi@fred.dev>