### PR TITLE
fix: 1053 - remove bars for telemetry

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -67,6 +67,12 @@ cluster provisioning process spinning up the services, and validates the livenes
 		// todo remove this dependency from create.go
 		hostedZoneName := viper.GetString("aws.hostedzonename")
 
+		if !globalFlags.UseTelemetry {
+			informUser("Telemetry Disabled", globalFlags.SilentMode)
+		} else {
+			pkg.InformUser("Sending installation telemetry", globalFlags.SilentMode)
+		}
+
 		if globalFlags.UseTelemetry {
 			if err := wrappers.SendSegmentIoTelemetry(hostedZoneName, pkg.MetricMgmtClusterInstallStarted); err != nil {
 				log.Warn().Msgf("%s", err)

--- a/cmd/createGithub.go
+++ b/cmd/createGithub.go
@@ -55,10 +55,6 @@ var createGithubCmd = &cobra.Command{
 
 		progressPrinter.IncrementTracker("step-0", 1)
 
-		if !globalFlags.UseTelemetry {
-			informUser("Telemetry Disabled", globalFlags.SilentMode)
-		}
-
 		//* create github teams in the org and gitops repo
 		informUser("Creating gitops/metaphor repos", globalFlags.SilentMode)
 		err = githubAddCmd.RunE(cmd, args)

--- a/cmd/createGitlab.go
+++ b/cmd/createGitlab.go
@@ -60,9 +60,6 @@ var createGitlabCmd = &cobra.Command{
 
 		progressPrinter.AddTracker("step-softserve", "Prepare Temporary Repo ", 4)
 		progressPrinter.IncrementTracker("step-softserve", 1)
-		if !globalFlags.UseTelemetry {
-			informUser("Telemetry Disabled", globalFlags.SilentMode)
-		}
 		directory := fmt.Sprintf("%s/gitops/terraform/base", config.K1FolderPath)
 		informUser("Creating K8S Cluster", globalFlags.SilentMode)
 		terraform.ApplyBaseTerraform(globalFlags.DryRun, directory)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -129,7 +129,6 @@ validated and configured.`,
 		progressPrinter.AddTracker("step-download", pkg.DownloadDependencies, 3)
 		progressPrinter.AddTracker("step-gitops", pkg.CloneAndDetokenizeGitOpsTemplate, 1)
 		progressPrinter.AddTracker("step-ssh", pkg.CreateSSHKey, 1)
-		progressPrinter.AddTracker("step-telemetry", pkg.SendTelemetry, 1)
 
 		progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), globalFlags.SilentMode)
 
@@ -137,6 +136,12 @@ validated and configured.`,
 
 		var telemetryHandler handlers.TelemetryHandler
 		viper.Set("use-telemetry", globalFlags.UseTelemetry)
+
+		if !globalFlags.UseTelemetry {
+			informUser("Telemetry Disabled", globalFlags.SilentMode)
+		} else {
+			pkg.InformUser("Sending installation telemetry", globalFlags.SilentMode)
+		}
 		if globalFlags.UseTelemetry {
 
 			// Instantiates a SegmentIO client to use send messages to the segment API.
@@ -281,8 +286,6 @@ validated and configured.`,
 
 		viper.WriteConfig()
 
-		//! tracker 8
-		progressPrinter.IncrementTracker("step-telemetry", 1)
 		time.Sleep(time.Millisecond * 100)
 
 		informUser("init is done!\n", globalFlags.SilentMode)

--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -93,16 +93,14 @@ func runLocal(cmd *cobra.Command, args []string) error {
 	progressPrinter.AddTracker("step-github", "Setup gitops on github", 3)
 	progressPrinter.AddTracker("step-base", "Setup base cluster", 2)
 	progressPrinter.AddTracker("step-apps", "Install apps to cluster", 4)
-	progressPrinter.AddTracker("step-telemetry", pkg.SendTelemetry, 2)
 	if useTelemetry {
 		if err := wrappers.SendSegmentIoTelemetry("", pkg.MetricMgmtClusterInstallStarted); err != nil {
 			log.Error().Err(err).Msg("")
 		}
-		pkg.InformUser("Telemetry info sent", silentMode)
+		log.Info().Msg("Telemetry info sent")
 	} else {
 		pkg.InformUser("Telemetry skipped by user request", silentMode)
 	}
-	progressPrinter.IncrementTracker("step-telemetry", 1)
 
 	// todo need to add go channel to control when ngrok should close
 	// and use context to handle closing the open goroutine/connection
@@ -447,11 +445,10 @@ func runLocal(cmd *cobra.Command, args []string) error {
 		if err = wrappers.SendSegmentIoTelemetry("", pkg.MetricMgmtClusterInstallCompleted); err != nil {
 			log.Error().Err(err).Msg("")
 		}
-		pkg.InformUser("Telemetry info sent", silentMode)
+		log.Info().Msg("Telemetry info sent")
 	} else {
 		pkg.InformUser("Telemetry skipped by user request", silentMode)
 	}
-	progressPrinter.IncrementTracker("step-telemetry", 1)
 
 	pkg.InformUser("Kubefirst installation finished successfully", silentMode)
 	return nil

--- a/cmd/local/prerun.go
+++ b/cmd/local/prerun.go
@@ -37,6 +37,7 @@ func validateLocal(cmd *cobra.Command, args []string) error {
 	log.Info().Msg("sending init started metric")
 
 	if useTelemetry {
+		pkg.InformUser("Sending installation telemetry", silentMode)
 		if err := wrappers.SendSegmentIoTelemetry("", pkg.MetricInitStarted); err != nil {
 			log.Error().Err(err).Msg("")
 		}


### PR DESCRIPTION
Fix: 
 - #1053 

Sample of the output:

```bash 
-----------
Follow your logs with:
   tail -f  /app/logs/log_1673272819.log

-----------
- Sending installation telemetry
Download dependencies         ... 33.3% [#########...................] [1 in 700.264ms]
Download dependencies         ... done! [3 in 8.862s]
Create SSH keys               ... done! [1 in 8.874s]
Clone and Detokenize (GitOps) ... done! [1 in 10.085s]
- initialization step is done!
Process Parameters            ... done! [1 in 10.34s]
- Creating github resources with terraform
- Created gitops Repo in github.com/ABC
- pushing local detokenized gitops content to new remote github.com/ABC
Setup gitops on github        ... done! [3 in 1m5.548s]
- create initial argocd repository
- helm repo add argo https://argoproj.github.io/argo-helm and helm repo update
- helm install argo and wait
- ArgoCD is running, continuing
- Setting argocd username and password credentials
- argocd username and password credentials set successfully
- Getting an argocd auth token
- argocd admin auth token set
- applying the registry application to argocd
- waiting for Vault to be ready...
- configuring vault with terraform
- vault terraform executed successfully
- Vault secret created
- applying users terraform
Setup base cluster            ... done! [2 in 4m22.629s]
Install apps to cluster       ... done! [4 in 4m22.629s]
- executed users terraform successfully
- To use your cluster port-forward - argocd
- If not automatically injected, your kubeconfig is at:
- k3d kubeconfig get kubefirst
- Expose Argo-CD
- kubectl -n argocd port-forward svc/argocd-server 8080:80
- Argo User: admin
- Argo Password: ABC
```


Signed-off-by: 6za <53096417+6za@users.noreply.github.com>