### PR TITLE
feat: add e2e tests for metaphor local and cloud

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -25,3 +25,7 @@ tasks:
   integration-test-for-tls-localdev:
     # GOFLAGS="-count=1" disable cache on tests
     - GOFLAGS="-count=1" go test -v -run TestArgoCertificateIntegration ./internal/ssl
+  local-end-to-end-tests:
+    - go test -v -run TestLocalMetaphorFrontendEndToEnd ./tests -count=1
+  cloud-end-to-end-tests:
+    - go test -v -run TestCloudMetaphorsEndToEnd ./tests -count=1

--- a/tests/metaphor-frontend_test.go
+++ b/tests/metaphor-frontend_test.go
@@ -1,0 +1,82 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/kubefirst/kubefirst/configs"
+	"github.com/kubefirst/kubefirst/pkg"
+	"github.com/spf13/viper"
+	"net/http"
+	"testing"
+)
+
+// TestLocalMetaphorFrontendEndToEnd tests the Metaphor frontend, and look for a http response code of 200
+func TestLocalMetaphorFrontendEndToEnd(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping end to tend test")
+	}
+
+	resp, err := http.Get(pkg.MetaphorFrontendSlimTLS)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	fmt.Println("HTTP status code:", resp.StatusCode)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("HTTP status code is not 200")
+	}
+}
+
+// TestCloudMetaphorsEndToEnd tests the Metaphor frontend, and look for a http response code of 200 for cloud
+func TestCloudMetaphorsEndToEnd(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping end to tend test")
+	}
+
+	config := configs.ReadConfig()
+	if err := pkg.SetupViper(config); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	testCases := []struct {
+		name     string
+		url      string
+		expected int
+	}{
+		{name: "metaphor frontend development", url: "https://metaphor-frontend-development." + viper.GetString("aws.hostedzonename"), expected: http.StatusOK},
+		{name: "metaphor frontend staging", url: "https://metaphor-frontend-staging." + viper.GetString("aws.hostedzonename"), expected: http.StatusOK},
+		{name: "metaphor frontend production", url: "https://metaphor-frontend-production." + viper.GetString("aws.hostedzonename"), expected: http.StatusOK},
+		{name: "metaphor NodeJs development", url: "https://metaphor-development." + viper.GetString("aws.hostedzonename") + "/app", expected: http.StatusOK},
+		{name: "metaphor NodeJs staging", url: "https://metaphor-staging." + viper.GetString("aws.hostedzonename") + "/app", expected: http.StatusOK},
+		{name: "metaphor NodeJs production", url: "https://metaphor-production." + viper.GetString("aws.hostedzonename") + "/app", expected: http.StatusOK},
+		{name: "metaphor Go development", url: "https://metaphor-go-development." + viper.GetString("aws.hostedzonename") + "/app", expected: http.StatusOK},
+		{name: "metaphor Go staging", url: "https://metaphor-go-staging." + viper.GetString("aws.hostedzonename") + "/app", expected: http.StatusOK},
+		{name: "metaphor Go production", url: "https://metaphor-go-production." + viper.GetString("aws.hostedzonename") + "/app", expected: http.StatusOK},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			resp, err := http.Get(tc.url)
+			if err != nil {
+				t.Errorf(err.Error())
+				return
+			}
+			defer resp.Body.Close()
+
+			fmt.Println("HTTP status code:", resp.StatusCode)
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("HTTP status code is not 200")
+			}
+			if resp.StatusCode != tc.expected {
+				t.Errorf("[%s] wanted http status code (%d), got (%d)", tc.url, resp.StatusCode, tc.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
closes #1086 

Signed-off-by: João Vanzuita <joao@kubeshop.io>