### PR TITLE
feat: update nodejs

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.x
     - run: pip install mkdocs-material


### PR DESCRIPTION
Problem: Node.js 12 actions are deprecated on publish docs action.

![image](https://user-images.githubusercontent.com/19623668/212898402-4f12d355-2c7f-4558-b9ee-d497c17059b6.png)

Fix: Update python setup to latest version, which has Node.js 16.

Signed-off-by: Jessica Marinho <jessica@kubeshop.io>