### PR TITLE
GitHub webhook token

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/kubefirst/kubefirst/cmd/local"
-	"github.com/kubefirst/kubefirst/configs"
 	"os"
+
+	"github.com/kubefirst/kubefirst/cmd/local"
+	"github.com/kubefirst/kubefirst/cmd/tool"
+	"github.com/kubefirst/kubefirst/configs"
 
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 	"github.com/spf13/cobra"
@@ -43,4 +45,5 @@ func Execute() {
 func init() {
 	cobra.OnInitialize()
 	rootCmd.AddCommand(local.NewCommand())
+	rootCmd.AddCommand(tool.NewCommand())
 }

--- a/cmd/tool/command.go
+++ b/cmd/tool/command.go
@@ -1,0 +1,42 @@
+package tool
+
+import "github.com/spf13/cobra"
+
+var (
+	lastTunnel string
+	owner      string
+	repo       string
+)
+
+func NewCommand() *cobra.Command {
+
+	toolCmd := &cobra.Command{
+		Use:   "tool",
+		Short: "general tools set",
+		Long:  "TBD",
+		RunE:  runTool,
+		// PostRunE: runPostCivo,
+	}
+
+	// wire up new commands
+	toolCmd.AddCommand(WebhookUpdater())
+
+	return toolCmd
+}
+
+func WebhookUpdater() *cobra.Command {
+
+	webhookUpdater := &cobra.Command{
+		Use:     "tool",
+		Short:   "comand to be used check/update ngrok based webhooks",
+		Long:    "TBD",
+		RunE:    runWebhookUpdater,
+		PreRunE: validateWebhookUpdater,
+		// PostRunE: runPostCivo,
+	}
+
+	webhookUpdater.Flags().StringVar(&owner, "repo", "", "repository that will observed fro changes on tunnels")
+	webhookUpdater.Flags().StringVar(&repo, "owner", "", "owner of repository that will observed fro changes on tunnels, organization or user")
+
+	return webhookUpdater
+}

--- a/cmd/tool/command.go
+++ b/cmd/tool/command.go
@@ -15,7 +15,6 @@ func NewCommand() *cobra.Command {
 		Short: "general tools set",
 		Long:  "TBD",
 		RunE:  runTool,
-		// PostRunE: runPostCivo,
 	}
 
 	// wire up new commands
@@ -27,12 +26,11 @@ func NewCommand() *cobra.Command {
 func WebhookUpdater() *cobra.Command {
 
 	webhookUpdater := &cobra.Command{
-		Use:     "tool",
+		Use:     "webhook-checker",
 		Short:   "comand to be used check/update ngrok based webhooks",
 		Long:    "TBD",
 		RunE:    runWebhookUpdater,
 		PreRunE: validateWebhookUpdater,
-		// PostRunE: runPostCivo,
 	}
 
 	webhookUpdater.Flags().StringVar(&owner, "repo", "", "repository that will observed fro changes on tunnels")

--- a/cmd/tool/command.go
+++ b/cmd/tool/command.go
@@ -33,8 +33,8 @@ func WebhookUpdater() *cobra.Command {
 		PreRunE: validateWebhookUpdater,
 	}
 
-	webhookUpdater.Flags().StringVar(&owner, "repo", "", "repository that will observed fro changes on tunnels")
-	webhookUpdater.Flags().StringVar(&repo, "owner", "", "owner of repository that will observed fro changes on tunnels, organization or user")
+	webhookUpdater.Flags().StringVar(&owner, "owner", "", "repository that will observed fro changes on tunnels")
+	webhookUpdater.Flags().StringVar(&repo, "repo", "", "owner of repository that will observed fro changes on tunnels, organization or user")
 
 	return webhookUpdater
 }

--- a/cmd/tool/tool.go
+++ b/cmd/tool/tool.go
@@ -1,0 +1,8 @@
+package tool
+
+import "github.com/spf13/cobra"
+
+func runTool(cmd *cobra.Command, args []string) error {
+	//Add some docs
+	return nil
+}

--- a/cmd/tool/webhookUpdater.go
+++ b/cmd/tool/webhookUpdater.go
@@ -1,0 +1,123 @@
+package tool
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/kubefirst/kubefirst/internal/githubWrapper"
+	"github.com/kubefirst/kubefirst/internal/k8s"
+	"github.com/kubefirst/kubefirst/pkg"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+//Run a constant checket for ngrok hook state and update  client if found changes.
+
+func runWebhookUpdater(cmd *cobra.Command, args []string) error {
+	//while true
+	//Call Some SDK to validate NGROK
+	//CURL: curl http://localhost:3000/api/tunnels
+	//Check if previous tunnel is the same of the new tunnel public address
+	//if matches, do nothing - sleep/exit
+	//if don't matches
+	//USE GITHUB token from ENV Variable(it will come from vault later)
+	// USe token to create a webhook
+	// USe token to remove  old webhook
+	//Where old webhook is stored?
+	//	- configMap?
+	//	- can it be queried by some label on github?
+	// - start witha pre-defined name
+	gitHubClient := githubWrapper.New()
+	clientset, err := k8s.GetClientSet(false)
+	if err != nil {
+		return fmt.Errorf("error when connecting to k8s: %v", err)
+	}
+	atlantisSecretClient := clientset.CoreV1().Secrets("atlantis")
+	for true {
+		payload, err := CheckNgrokTunnel()
+		if err != nil {
+			log.Warn().Msgf("error checking status of tunnel: %v", err)
+			// We will try again soon, once cluster is more ready
+			continue
+		}
+		if len(payload.Tunnels) > 0 {
+			log.Warn().Msgf("error reading tunnel info:  no tunnels")
+			// We will try again soon, once cluster is more ready
+			continue
+		}
+
+		hookName := "ngrok_atlantis"
+		hookURL := payload.Tunnels[0].PublicURL + "/events"
+		if hookURL == lastTunnel {
+			// Nothing to be done
+			continue
+		}
+		hookSecret := k8s.GetSecretValue(atlantisSecretClient, "atlantis-secrets", "ATLANTIS_GH_WEBHOOK_SECRET")
+		hookEvents := []string{"issue_comment", "pull_request", "pull_request_review", "push"}
+		err = gitHubClient.UpdateWebhook(owner, repo, hookName, hookURL, hookSecret, hookEvents)
+		if err != nil {
+			return fmt.Errorf("error when updating a webhook: %v", err)
+		}
+		lastTunnel = hookURL
+		time.Sleep(20 * time.Second)
+	}
+
+	return nil
+}
+
+//atlantis  get secrets atlantis-secrets
+
+func validateWebhookUpdater(cmd *cobra.Command, args []string) error {
+	if len(repo) < 1 || len(owner) < 1 {
+		return fmt.Errorf("both repo(%s) and owner(%s) must be provided in order for webhookupdater to work as expected", repo, owner)
+	}
+	log.Info().Msgf("Validation: Success repo(%s) and owner(%s) provided as epxected", repo, owner)
+	return nil
+}
+
+type NgrokTunnel struct {
+	Tunnels []struct {
+		Name      string `json:"name"`
+		ID        string `json:"ID"`
+		URI       string `json:"uri"`
+		PublicURL string `json:"public_url"`
+		Proto     string `json:"proto"`
+		Config    struct {
+			Addr    string `json:"addr"`
+			Inspect bool   `json:"inspect"`
+		} `json:"config"`
+	} `json:"tunnels"`
+	URI string `json:"uri"`
+}
+
+func CheckNgrokTunnel() (*NgrokTunnel, error) {
+
+	url := "http://ngrok.ngrok-agent.svc.cluster.local:4040/api/tunnels"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return &NgrokTunnel{}, err
+	}
+	req.Header.Add("Content-Type", pkg.JSONContentType)
+	req.Header.Add("Accept", pkg.JSONContentType)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return &NgrokTunnel{}, err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return &NgrokTunnel{}, err
+	}
+
+	var payload NgrokTunnel
+	err = json.Unmarshal(body, &payload)
+	if err != nil {
+		log.Warn().Msgf("%s", err)
+	}
+	return &payload, nil
+}

--- a/internal/githubWrapper/github.go
+++ b/internal/githubWrapper/github.go
@@ -281,7 +281,7 @@ func (g GithubSession) RetrySearchPullRequestComment(
 	return false, nil
 }
 
-func (g GithubSession) UpdateWebhook(owner, repo, hookName, hookUrl, hookSecret string, hookEvents []string) error {
+func (g GithubSession) UpdateWebhook(owner, repo, hookName, hookUrl, lastHookUrl, hookSecret string, hookEvents []string) error {
 	// List webhooks
 	// Get webhook with name that matches, if exist delete it.
 	// Create new webhook with same name
@@ -294,10 +294,19 @@ func (g GithubSession) UpdateWebhook(owner, repo, hookName, hookUrl, hookSecret 
 	}
 	for i, hook := range hooks {
 		log.Debug().Msgf("%s, %s", i, hook)
-		if hook.Name == &hookName {
-			_, err := g.gitClient.Repositories.DeleteHook(g.context, owner, repo, *hook.ID)
+		oldHookURL := fmt.Sprint(hook.Config["url"])
+		fmt.Printf("\n Found webhook: %v", *hook)
+		fmt.Printf("\n Found webhook: %v", hook)
+		fmt.Printf("\n Found webhook: %v", oldHookURL)
+		//name of hook seems to be no-ops all are called "Web"
+		if oldHookURL == lastHookUrl {
+			fmt.Printf("\n Found match!! webhook: %v", *hook)
+			fmt.Printf("\n Found match!! webhook: %v", hook)
+			oldHookID := *hook.ID
+			fmt.Printf("\n Found match!! webhook: %d", oldHookID)
+			_, err := g.gitClient.Repositories.DeleteHook(g.context, owner, repo, oldHookID)
 			if err != nil {
-				return fmt.Errorf("error when removing a webhook: %v", err)
+				fmt.Printf("\n error when removing a webhook: %v", err)
 			}
 			break
 		}

--- a/internal/k8s/kubernetes.go
+++ b/internal/k8s/kubernetes.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	coreV1Types "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -546,4 +547,18 @@ func CreateSecret(namespace string, secretName string, data map[string][]byte) e
 	}
 
 	return nil
+}
+
+func GetK8SConfig() (*kubernetes.Clientset, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return &kubernetes.Clientset{}, err
+	}
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return &kubernetes.Clientset{}, err
+	}
+	fmt.Println("Config used")
+	return clientSet, nil
+
 }


### PR DESCRIPTION
Explore:
- #1227

Provide a way to have ngrok in cluster using the following template, using informations we already collect from installation time and store on vault:

```yaml 
apiVersion: v1
kind: ServiceAccount
metadata:
  name: ngrok-agent-sa
  namespace: ngrok-agent
--- 
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: ngrok-agent-cr
rules:
  - apiGroups: [""]
    resources: ["secrets"]
    verbs: ["get", "list", "watch"]
--- 
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: ngrok-agent-crb
subjects:
- kind: ServiceAccount
  name: ngrok-agent-sa
  namespace: ngrok-agent
roleRef:
  kind: ClusterRole
  name: ngrok-agent-cr
  apiGroup: rbac.authorization.k8s.io


---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ngrok-agent
  namespace: ngrok-agent
spec:
  selector:
    matchLabels:
      app: ngrok-agent
  template:
    metadata:
      labels:
        app: ngrok-agent
    spec:
      containers:
      - args:
        - http
        - atlantis.atlantis.svc.cluster.local:80

        image: docker.io/ngrok/ngrok:3
        name: ngrok-agent
        ports:
        - containerPort: 4040
          name: web
        readinessProbe:
          httpGet:
            path: /status
            port: 4040
            scheme: HTTP
          initialDelaySeconds: 10
          periodSeconds: 20

---
apiVersion: v1
kind: Service
metadata:
  name: ngrok-agent
  namespace: ngrok-agent
spec:
  ports:
  - name: web
    port: 4040
    targetPort: 4040
  selector:
    app: ngrok-agent
    
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ngrok-checker
spec:
  selector:
    matchLabels:
      app: ngrok-checker
  template:
    metadata:
      labels:
        app: ngrok-checker
    spec:
      serviceAccount: ngrok-agent-sa
      containers:
      - command:
        - /usr/local/bin/kubefirst
        - tool 
        - webhook-checker 
        - --owner 
        - kxdroid 
        - --repo 
        - gitops
        image: docker.io/6zar/k1-webhook-checker:a7eee22
        env:
        - name: KUBEFIRST_GITHUB_AUTH_TOKEN
          valueFrom:
          secretKeyRef:
            name: ngrok-secrets
            key: PERSONAL_ACCESS_TOKEN
            optional: false 
        name: ngrok-checker
---
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: ngrok-secrets
  annotations:
    argocd.argoproj.io/sync-wave: "0"
spec:
  target:
    name: ngrok-secrets
  secretStoreRef:
    kind: ClusterSecretStore
    name: vault-secrets-backend
  refreshInterval: 10s
  dataFrom:
    - extract:      
        key: /ci-secrets

```