### PR TITLE
Add check to clean command to remove cluster resources first.

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -30,8 +30,8 @@ import (
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Creates a Kubefirst management cluster",
-	Long: `Based on Kubefirst init command, that creates the Kubefirst configuration file, this command start the
-cluster provisioning process spinning up the services, and validates the liveness of the provisioned services.`,
+	Long: `Based on the kubefirst init command which creates the kubefirst configuration file, this command starts the
+cluster provisioning process, spinning up the services, and validates the liveness of the provisioned services.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		start := time.Now()
 		defer func() {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -16,10 +16,9 @@ import (
 // destroyCmd represents the destroy command
 var destroyCmd = &cobra.Command{
 	Use:   "destroy",
-	Short: "destroy Kubefirst management cluster",
-	Long:  "destroy all the resources installed via Kubefirst installer",
+	Short: "Destroy Kubefirst management cluster",
+	Long:  "Destroy all the resources installed via Kubefirst installer",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		//Destroy is implemented based on the flavor selected.
 		if viper.GetString("cloud") == pkg.CloudAws {
 			//just in case, we need downstream
@@ -45,7 +44,7 @@ var destroyCmd = &cobra.Command{
 			log.Println("terraform base destruction complete")
 
 		} else {
-			return fmt.Errorf("not supported mode")
+			return fmt.Errorf("nothing to destroy - it looks like you haven't created a cluster yet")
 		}
 
 		time.Sleep(time.Millisecond * 100)


### PR DESCRIPTION
Signed-off-by: echoboomer <scott@echoboomer.net>

Addresses: https://github.com/kubefirst/kubefirst/issues/1248

Add a check to the `clean` command to advise a user to first run `kubefirst cluster destroy` if there are flags indicating resources have already been created. This could be automated, but I think it's important for the user to understand the implications before running.

Also changes the message in `cmd/destroy.go` returned from the `viper.GetString("cloud")` check to more plainly indicate that resources likely don't exist if you haven't already run `init` since there shouldn't be a scenario where the flag is something else or doesn't exist.