### PR TITLE
Remove legacy refs to prior package name.

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -6,7 +6,7 @@ Join the `kubefirst` slack workspace by following [this link](https://join.slack
 
 ### Issues
 
-To open an issue or request a feature, submit a new issue against the kubefirst repo [here](https://github.com/kubefirst/nebulous/issues)
+To open an issue or request a feature, submit a new issue against the kubefirst repo [here](https://github.com/kubefirst/kubefirst/issues)
 
 ### Zoom
 
@@ -15,4 +15,3 @@ We're happy to engage with you to talk through your use cases and any points of 
 ### Email
 
 To request more information or schedule a demo email <info@kubefirst.com>
-

--- a/internal/progressPrinter/progress.go
+++ b/internal/progressPrinter/progress.go
@@ -10,14 +10,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-//ActionTracker Struct used to manage tracker object
+// ActionTracker Struct used to manage tracker object
 // This object may evolve with more properties in th future
 // when we have more fancier UI tools/styles.
 type ActionTracker struct {
 	Tracker *progress.Tracker
 }
 
-//progressPrinter General state object
+// progressPrinter General state object
 type progressPrinter struct {
 	Trackers map[string]*ActionTracker
 	pw       progress.Writer
@@ -26,10 +26,10 @@ type progressPrinter struct {
 var instance *progressPrinter
 var once sync.Once
 
-//GetInstance  Function used to initialize the component once in the execution.
+// GetInstance  Function used to initialize the component once in the execution.
 // Usually called from the `cmd`  `init` func or as early as possible on the execution.
 //
-//	import ("github.com/kubefirst/nebulous/pkg")
+//	import ("github.com/kubefirst/kubefirst/pkg")
 //	func init() {
 //			progressPrinter.GetInstance()
 //			progressPrinter.SetupProgress(5) // Number of bars for the entire run.
@@ -74,7 +74,7 @@ func SetupProgress(numTrackers int, silentMode bool) {
 	go instance.pw.Render()
 }
 
-//CreateTracker Initialise a tracker object
+// CreateTracker Initialise a tracker object
 //
 // Prefer `AddTracker` to create trackers, due to simplicity.
 func CreateTracker(title string, total int64) *progress.Tracker {
@@ -108,12 +108,12 @@ func AddTracker(key string, title string, total int64) string {
 	return key
 }
 
-//TotalOfTrackers Returns the number of initialized Trackers
+// TotalOfTrackers Returns the number of initialized Trackers
 func TotalOfTrackers() int {
 	return len(instance.Trackers)
 }
 
-//IncrementTracker Increments a tracker based on the provided key
+// IncrementTracker Increments a tracker based on the provided key
 // if key is unkown it will error out.
 // Sample of usage:
 //


### PR DESCRIPTION
Signed-off-by: echoboomer <scott@echoboomer.net>

There were a couple spots that still referenced legacy naming. While the link to open Issues does redirect properly, it was still worth removing these.