### PR TITLE
fix: UT errors

### DIFF
--- a/cmd/civo/civo.go
+++ b/cmd/civo/civo.go
@@ -227,7 +227,7 @@ func runCivo(cmd *cobra.Command, args []string) error {
 		pkg.InformUser("generating your new metaphor-frontend repository", silentMode)
 		metaphorRepo, err := gitClient.CloneRefSetMain(metaphorFrontendTemplateBranch, k1MetaphorDir, metaphorFrontendTemplateURL)
 		if err != nil {
-			log.Info().Msgf("error opening repo at:", k1MetaphorDir)
+			log.Info().Msgf("error opening repo at: %s", k1MetaphorDir)
 		}
 
 		log.Info().Msg("metaphor repository clone complete")

--- a/internal/civo/bootstrapSecrets.go
+++ b/internal/civo/bootstrapSecrets.go
@@ -42,7 +42,7 @@ func BootstrapCivoMgmtCluster(dryRun bool, kubeconfigPath string) error {
 	}
 	_, err = clientset.CoreV1().Secrets("external-dns").Create(context.TODO(), civoSecret, metav1.CreateOptions{})
 	if err != nil {
-		log.Info().Msgf("Error:", err)
+		log.Info().Msgf("Error: %s", err)
 		return errors.New("error creating kubernetes secret: external-dns/civo-creds")
 	}
 
@@ -57,7 +57,7 @@ func BootstrapCivoMgmtCluster(dryRun bool, kubeconfigPath string) error {
 	_, err = clientset.CoreV1().Secrets("external-secrets-operator").Create(context.TODO(), externalSecretOperatorSecret, metav1.CreateOptions{})
 
 	if err != nil {
-		log.Info().Msgf("Error:", err)
+		log.Info().Msgf("Error: %s", err)
 		return errors.New("error creating kubernetes secret: external-secrets-operator/vault-token")
 	}
 	log.Info().Msg("created secret: external-secrets-operator/vault-token")

--- a/internal/gitClient/git.go
+++ b/internal/gitClient/git.go
@@ -101,7 +101,7 @@ func SetRefToMainBranch(repo *git.Repository) (*git.Repository, error) {
 	return repo, nil
 }
 
-//! deprecated
+// ! deprecated
 func CloneLocalRepo(repoPath string) (*git.Repository, error) {
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
@@ -192,7 +192,7 @@ func PushChanges(repo *git.Repository, remoteName string, gitHubToken string) er
 		},
 	})
 	if err != nil {
-		log.Info().Msgf("Error creating remote %s at: %s - %s", remoteName, err)
+		log.Info().Msgf("Error creating remote %s at: %s", remoteName, err)
 		return err
 	}
 	return nil
@@ -206,13 +206,13 @@ func AddRemote(newGitRemoteURL, remoteName string, repo *git.Repository) error {
 		URLs: []string{newGitRemoteURL},
 	})
 	if err != nil {
-		log.Info().Msgf("Error creating remote %s at: %s - %s", remoteName, newGitRemoteURL)
+		log.Info().Msgf("Error creating remote %s at: %s", remoteName, newGitRemoteURL)
 		return err
 	}
 	return nil
 }
 
-//! deprecated
+// ! deprecated
 // CloneRepoAndDetokenizeTemplate - clone repo using CloneRepoAndDetokenizeTemplate that uses fallback rule to try to capture version
 func CloneRepoAndDetokenizeTemplate(githubOwner, repoName, folderName string, branch string, tag string) (string, error) {
 	config := configs.ReadConfig()
@@ -315,7 +315,7 @@ func PopulateRepoWithToken(owner string, repo string, sourceFolder string, gitHo
 	return nil
 }
 
-//! deprecated
+// ! deprecated
 func CloneGitOpsRepo() {
 
 	config := configs.ReadConfig()
@@ -360,14 +360,14 @@ func Commit(repo *git.Repository, commitMsg string) error {
 	log.Printf(commitMsg)
 	status, err := w.Status()
 	if err != nil {
-		log.Info().Msgf("error getting worktree status", err)
+		log.Info().Msgf("error getting worktree status: %s", err)
 		return err
 	}
 
 	for file, _ := range status {
 		_, err = w.Add(file)
 		if err != nil {
-			log.Info().Msgf("error getting worktree status", err)
+			log.Info().Msgf("error getting worktree status: %s", err)
 			return err
 		}
 	}
@@ -687,7 +687,7 @@ func UpdateLocalTerraformFilesAndPush(githubHost, githubOwner, k1Dir, localRepo,
 	return nil
 }
 
-//! deprecated
+// ! deprecated
 // CloneBranch clone a branch and returns a pointer to git.Repository
 func CloneBranch(branch, repoLocalPath, repoURL string) (*git.Repository, error) {
 
@@ -703,7 +703,7 @@ func CloneBranch(branch, repoLocalPath, repoURL string) (*git.Repository, error)
 	return repo, nil
 }
 
-//! deprecated
+// ! deprecated
 // CloneBranchSetMain clone a branch and returns a pointer to git.Repository
 func CloneBranchSetMain(branch, repoURL, repoLocalPath string) (*git.Repository, error) {
 
@@ -727,7 +727,7 @@ func CloneBranchSetMain(branch, repoURL, repoLocalPath string) (*git.Repository,
 	return repo, nil
 }
 
-//! deprecated
+// ! deprecated
 // CloneTag clone a repository using a tag value, and returns a pointer to *git.Repository
 func CloneTag(githubOrg, repoLocalPath, repoName, tag string) (*git.Repository, error) {
 
@@ -749,7 +749,7 @@ func CloneTag(githubOrg, repoLocalPath, repoName, tag string) (*git.Repository, 
 	return repo, nil
 }
 
-//! deprecated
+// ! deprecated
 // CloneTagSetMain  CloneTag plus fixes branch to be main
 func CloneTagSetMain(repoLocalPath string, githubOrg string, repoName string, tag string) (*git.Repository, error) {
 
@@ -767,7 +767,7 @@ func CloneTagSetMain(repoLocalPath string, githubOrg string, repoName string, ta
 	return repo, nil
 }
 
-//! deprecated
+// ! deprecated
 // SetToMainBranch point branch or tag to main
 func SetToMainBranch(repo *git.Repository) (*git.Repository, error) {
 	w, _ := repo.Worktree()
@@ -790,7 +790,7 @@ func SetToMainBranch(repo *git.Repository) (*git.Repository, error) {
 	return repo, nil
 }
 
-//! deprecated
+// ! deprecated
 // CheckoutTag repository checkout based on a tag
 func CheckoutTag(repo *git.Repository, tag string) error {
 
@@ -809,7 +809,7 @@ func CheckoutTag(repo *git.Repository, tag string) error {
 	return nil
 }
 
-//! deprecated
+// ! deprecated
 // CreateGitHubRemote create a remote repository entry
 func CreateGitHubRemote(gitOpsLocalRepoPath string, gitHubUser string, repoName string) error {
 

--- a/internal/gitClient/git.go
+++ b/internal/gitClient/git.go
@@ -101,7 +101,7 @@ func SetRefToMainBranch(repo *git.Repository) (*git.Repository, error) {
 	return repo, nil
 }
 
-// ! deprecated
+//! deprecated
 func CloneLocalRepo(repoPath string) (*git.Repository, error) {
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
@@ -212,7 +212,7 @@ func AddRemote(newGitRemoteURL, remoteName string, repo *git.Repository) error {
 	return nil
 }
 
-// ! deprecated
+//! deprecated
 // CloneRepoAndDetokenizeTemplate - clone repo using CloneRepoAndDetokenizeTemplate that uses fallback rule to try to capture version
 func CloneRepoAndDetokenizeTemplate(githubOwner, repoName, folderName string, branch string, tag string) (string, error) {
 	config := configs.ReadConfig()
@@ -315,7 +315,7 @@ func PopulateRepoWithToken(owner string, repo string, sourceFolder string, gitHo
 	return nil
 }
 
-// ! deprecated
+//! deprecated
 func CloneGitOpsRepo() {
 
 	config := configs.ReadConfig()
@@ -687,7 +687,7 @@ func UpdateLocalTerraformFilesAndPush(githubHost, githubOwner, k1Dir, localRepo,
 	return nil
 }
 
-// ! deprecated
+//! deprecated
 // CloneBranch clone a branch and returns a pointer to git.Repository
 func CloneBranch(branch, repoLocalPath, repoURL string) (*git.Repository, error) {
 
@@ -703,7 +703,7 @@ func CloneBranch(branch, repoLocalPath, repoURL string) (*git.Repository, error)
 	return repo, nil
 }
 
-// ! deprecated
+//! deprecated
 // CloneBranchSetMain clone a branch and returns a pointer to git.Repository
 func CloneBranchSetMain(branch, repoURL, repoLocalPath string) (*git.Repository, error) {
 
@@ -727,7 +727,7 @@ func CloneBranchSetMain(branch, repoURL, repoLocalPath string) (*git.Repository,
 	return repo, nil
 }
 
-// ! deprecated
+//! deprecated
 // CloneTag clone a repository using a tag value, and returns a pointer to *git.Repository
 func CloneTag(githubOrg, repoLocalPath, repoName, tag string) (*git.Repository, error) {
 
@@ -749,7 +749,7 @@ func CloneTag(githubOrg, repoLocalPath, repoName, tag string) (*git.Repository, 
 	return repo, nil
 }
 
-// ! deprecated
+//! deprecated
 // CloneTagSetMain  CloneTag plus fixes branch to be main
 func CloneTagSetMain(repoLocalPath string, githubOrg string, repoName string, tag string) (*git.Repository, error) {
 
@@ -767,7 +767,7 @@ func CloneTagSetMain(repoLocalPath string, githubOrg string, repoName string, ta
 	return repo, nil
 }
 
-// ! deprecated
+//! deprecated
 // SetToMainBranch point branch or tag to main
 func SetToMainBranch(repo *git.Repository) (*git.Repository, error) {
 	w, _ := repo.Worktree()
@@ -790,7 +790,7 @@ func SetToMainBranch(repo *git.Repository) (*git.Repository, error) {
 	return repo, nil
 }
 
-// ! deprecated
+//! deprecated
 // CheckoutTag repository checkout based on a tag
 func CheckoutTag(repo *git.Repository, tag string) error {
 
@@ -809,7 +809,7 @@ func CheckoutTag(repo *git.Repository, tag string) error {
 	return nil
 }
 
-// ! deprecated
+//! deprecated
 // CreateGitHubRemote create a remote repository entry
 func CreateGitHubRemote(gitOpsLocalRepoPath string, gitHubUser string, repoName string) error {
 


### PR DESCRIPTION
Small PR to fix the following errors:

```bash 
# github.com/kubefirst/kubefirst/internal/gitClient
internal/gitClient/git.go:195:3: (*github.com/rs/zerolog.Event).Msgf format %s reads arg #3, but call has 2 args
internal/gitClient/git.go:209:3: (*github.com/rs/zerolog.Event).Msgf format %s reads arg #3, but call has 2 args
internal/gitClient/git.go:363:18: (*github.com/rs/zerolog.Event).Msgf call has arguments but no formatting directives
internal/gitClient/git.go:370:19: (*github.com/rs/zerolog.Event).Msgf call has arguments but no formatting directives
# github.com/kubefirst/kubefirst/internal/civo
internal/civo/bootstrapSecrets.go:45:18: (*github.com/rs/zerolog.Event).Msgf call has arguments but no formatting directives
internal/civo/bootstrapSecrets.go:60:18: (*github.com/rs/zerolog.Event).Msgf call has arguments but no formatting directives
# github.com/kubefirst/kubefirst/cmd/civo
cmd/civo/civo.go:230:19: (*github.com/rs/zerolog.Event).Msgf call has arguments but no formatting directives
```

The errors above seems to be preventing UT to pass. 



Signed-off-by: 6za <53096417+6za@users.noreply.github.com>