### PR TITLE
bugfix: Implement wait for vault readiness to fix bug.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.13
 	github.com/caarlos0/env/v6 v6.9.3
 	github.com/caarlos0/sshmarshal v0.1.0
-	github.com/cert-manager/cert-manager v1.11.0
 	github.com/charmbracelet/bubbles v0.13.0
 	github.com/charmbracelet/bubbletea v0.22.0
 	github.com/charmbracelet/lipgloss v0.5.0
@@ -67,14 +66,16 @@ require (
 	github.com/inconshreveable/log15/v3 v3.0.0-testing.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/ginkgo/v2 v2.6.1 // indirect
+	github.com/onsi/gomega v1.24.2 // indirect
 	github.com/segmentio/backo-go v1.0.1 // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
-	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20221207184640-f3cff1453715 // indirect
-	sigs.k8s.io/gateway-api v0.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 )
 
@@ -186,5 +187,5 @@ require (
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,6 @@ github.com/caarlos0/sshmarshal v0.1.0/go.mod h1:7Pd/0mmq9x/JCzKauogNjSQEhivBclCQ
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.11.0 h1:sChJmoj9hhWuFkQMDYHnLHgYA/sSVil+hY+A1lnD3jY=
-github.com/cert-manager/cert-manager v1.11.0/go.mod h1:JCy2jvRi3Kp+qnRfw8TVYkOocj1thw/aDWFEHPpv4Q4=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/bubbles v0.13.0 h1:zP/ROH3wJEBqZWKIsD50ZKKlx3ydLInq3LdD/Nrlb8w=
@@ -420,6 +418,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -498,11 +497,13 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.6.1 h1:1xQPCjcqYw/J5LchOcp4/2q/jzJFjiAOc25chhnDw+Q=
+github.com/onsi/ginkgo/v2 v2.6.1/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1LFVcsAo=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.24.2 h1:J/tulyYK6JwBldPViHJReihxxZ+22FHs0piGjQAvoUE=
+github.com/onsi/gomega v1.24.2/go.mod h1:gs3J10IS7Z7r7eXRoNJIrNqU4ToQukCJhFtKrWgHWnk=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
 github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
@@ -519,6 +520,7 @@ github.com/pelletier/go-toml/v2 v2.0.0-beta.8 h1:dy81yyLYJDwMTifq24Oi/IslOslRrDS
 github.com/pelletier/go-toml/v2 v2.0.0-beta.8/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -547,6 +549,7 @@ github.com/rivo/uniseg v0.4.2/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
 github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
@@ -582,7 +585,9 @@ github.com/spf13/viper v1.11.0/go.mod h1:djo0X/bA5+tYVoCn+C7cAYJGcVn/qYLFTG8gdUs
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -590,7 +595,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
@@ -1014,8 +1021,6 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.26.1 h1:f+SWYiPd/GsiWwVRz+NbFyCgvv75Pk9NK6dlkZgpCRQ=
 k8s.io/api v0.26.1/go.mod h1:xd/GBNgR0f707+ATNyPmQ1oyKSgndzXij81FzWGsejg=
-k8s.io/apiextensions-apiserver v0.26.0 h1:Gy93Xo1eg2ZIkNX/8vy5xviVSxwQulsnUdQ00nEdpDo=
-k8s.io/apiextensions-apiserver v0.26.0/go.mod h1:7ez0LTiyW5nq3vADtK6C3kMESxadD51Bh6uz3JOlqWQ=
 k8s.io/apimachinery v0.26.1 h1:8EZ/eGJL+hY/MYCNwhmDzVqq2lPl3N3Bo8rvweJwXUQ=
 k8s.io/apimachinery v0.26.1/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
 k8s.io/client-go v0.26.1 h1:87CXzYJnAMGaa/IDDfRdhTzxk/wzGZ+/HUQpqgVSZXU=
@@ -1029,8 +1034,6 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/gateway-api v0.6.0 h1:v2FqrN2ROWZLrSnI2o91taHR8Sj3s+Eh3QU7gLNWIqA=
-sigs.k8s.io/gateway-api v0.6.0/go.mod h1:EYJT+jlPWTeNskjV0JTki/03WX1cyAnBhwBJfYHpV/0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -1,0 +1,105 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ReturnStatefulSetObject returns a matching v1.StatefulSet object based on the filters
+func ReturnStatefulSetObject(kubeConfigPath string, instanceOf string, namespace string, timeoutSeconds float64) (*appsv1.StatefulSet, error) {
+	clientset, err := GetClientSet(false, kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter
+	statefulSetListOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=%s", instanceOf),
+	}
+
+	// Create watch operation
+	objWatch, err := clientset.
+		AppsV1().
+		StatefulSets(namespace).
+		Watch(context.Background(), statefulSetListOptions)
+	if err != nil {
+		log.Fatal().Msgf("Error when attempting to search for StatefulSet: %s", err)
+	}
+	log.Info().Msgf("Waiting for %s StatefulSet to be created.", instanceOf)
+
+	objChan := objWatch.ResultChan()
+	for {
+		select {
+		case event, ok := <-objChan:
+			time.Sleep(time.Second * 1)
+			if !ok {
+				// Error if the channel closes
+				log.Fatal().Msgf("Error waiting for StatefulSet %s to be created: %s", instanceOf, err)
+			}
+			if event.
+				Object.(*appsv1.StatefulSet).Status.Replicas > 0 {
+				spec, err := clientset.AppsV1().StatefulSets(namespace).List(context.Background(), statefulSetListOptions)
+				if err != nil {
+					log.Fatal().Msgf("Error when looking for StatefulSet: %s", err)
+					return nil, err
+				}
+				return &spec.Items[0], nil
+			}
+		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
+			log.Error().Msg("The StatefulSet was not created within the timeout period.")
+			return nil, errors.New("The StatefulSet was not created within the timeout period.")
+		}
+	}
+}
+
+// WaitForStatefulSetReady waits for a target StatefulSet to become ready
+func WaitForStatefulSetReady(kubeConfigPath string, statefulset *appsv1.StatefulSet, timeoutSeconds int64) (bool, error) {
+	clientset, err := GetClientSet(false, kubeConfigPath)
+	if err != nil {
+		return false, err
+	}
+
+	// Format list for metav1.ListOptions for watch
+	configuredReplicas := statefulset.Status.Replicas
+	watchOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf(
+			"app.kubernetes.io/instance=%s", statefulset.ObjectMeta.Name),
+	}
+
+	// Create watch operation
+	objWatch, err := clientset.
+		AppsV1().
+		StatefulSets(statefulset.ObjectMeta.Namespace).
+		Watch(context.Background(), watchOptions)
+	if err != nil {
+		log.Fatal().Msgf("Error when attempting to wait for StatefulSet: %s", err)
+	}
+	log.Info().Msgf("Waiting for StatefulSet %s to be ready. This could take up to %v seconds.", statefulset.Name, timeoutSeconds)
+
+	objChan := objWatch.ResultChan()
+	for {
+		select {
+		case event, ok := <-objChan:
+			time.Sleep(time.Second * 1)
+			if !ok {
+				// Error if the channel closes
+				log.Fatal().Msgf("Error waiting StatefulSet: %s", err)
+			}
+			if event.
+				Object.(*appsv1.StatefulSet).
+				Status.AvailableReplicas == configuredReplicas {
+				log.Info().Msgf("All Pods in StatefulSet %s are ready.", statefulset.Name)
+				return true, nil
+			}
+		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
+			log.Error().Msg("The StatefulSet was not ready within the timeout period.")
+			return false, errors.New("The StatefulSet was not ready within the timeout period.")
+		}
+	}
+}

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -8,11 +8,68 @@ import (
 
 	"github.com/rs/zerolog/log"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ReturnStatefulSetObject returns a matching v1.StatefulSet object based on the filters
-func ReturnStatefulSetObject(kubeConfigPath string, instanceOf string, namespace string, timeoutSeconds float64) (*appsv1.StatefulSet, error) {
+// ReturnPodObject returns a matching v1.Pod object based on the filters
+func ReturnPodObject(kubeConfigPath string, matchLabel string, matchLabelValue string, namespace string, timeoutSeconds float64) (*v1.Pod, error) {
+	clientset, err := GetClientSet(false, kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter
+	podListOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", matchLabel, matchLabelValue),
+	}
+
+	// Create watch operation
+	objWatch, err := clientset.
+		CoreV1().
+		Pods(namespace).
+		Watch(context.Background(), podListOptions)
+	if err != nil {
+		log.Fatal().Msgf("Error when attempting to search for Pod: %s", err)
+	}
+	log.Info().Msgf("Waiting for %s Pod to be created.", matchLabelValue)
+
+	objChan := objWatch.ResultChan()
+	for {
+		select {
+		case event, ok := <-objChan:
+			time.Sleep(time.Second * 1)
+			if !ok {
+				// Error if the channel closes
+				log.Fatal().Msgf("Error waiting for %s Pod to be created: %s", matchLabelValue, err)
+			}
+			if event.
+				Object.(*v1.Pod).Status.Phase == "Pending" {
+				spec, err := clientset.CoreV1().Pods(namespace).List(context.Background(), podListOptions)
+				if err != nil {
+					log.Fatal().Msgf("Error when searching for Pod: %s", err)
+					return nil, err
+				}
+				return &spec.Items[0], nil
+			}
+			if event.
+				Object.(*v1.Pod).Status.Phase == "Running" {
+				spec, err := clientset.CoreV1().Pods(namespace).List(context.Background(), podListOptions)
+				if err != nil {
+					log.Fatal().Msgf("Error when searching for Pod: %s", err)
+					return nil, err
+				}
+				return &spec.Items[0], nil
+			}
+		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
+			log.Error().Msg("The Pod was not created within the timeout period.")
+			return nil, errors.New("The Pod was not created within the timeout period.")
+		}
+	}
+}
+
+// ReturnStatefulSetObject returns a matching appsv1.StatefulSet object based on the filters
+func ReturnStatefulSetObject(kubeConfigPath string, matchLabel string, matchLabelValue string, namespace string, timeoutSeconds float64) (*appsv1.StatefulSet, error) {
 	clientset, err := GetClientSet(false, kubeConfigPath)
 	if err != nil {
 		return nil, err
@@ -20,7 +77,7 @@ func ReturnStatefulSetObject(kubeConfigPath string, instanceOf string, namespace
 
 	// Filter
 	statefulSetListOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=%s", instanceOf),
+		LabelSelector: fmt.Sprintf("%s=%s", matchLabel, matchLabelValue),
 	}
 
 	// Create watch operation
@@ -31,7 +88,7 @@ func ReturnStatefulSetObject(kubeConfigPath string, instanceOf string, namespace
 	if err != nil {
 		log.Fatal().Msgf("Error when attempting to search for StatefulSet: %s", err)
 	}
-	log.Info().Msgf("Waiting for %s StatefulSet to be created.", instanceOf)
+	log.Info().Msgf("Waiting for %s StatefulSet to be created.", matchLabelValue)
 
 	objChan := objWatch.ResultChan()
 	for {
@@ -40,13 +97,13 @@ func ReturnStatefulSetObject(kubeConfigPath string, instanceOf string, namespace
 			time.Sleep(time.Second * 1)
 			if !ok {
 				// Error if the channel closes
-				log.Fatal().Msgf("Error waiting for StatefulSet %s to be created: %s", instanceOf, err)
+				log.Fatal().Msgf("Error waiting for %s StatefulSet to be created: %s", matchLabelValue, err)
 			}
 			if event.
 				Object.(*appsv1.StatefulSet).Status.Replicas > 0 {
 				spec, err := clientset.AppsV1().StatefulSets(namespace).List(context.Background(), statefulSetListOptions)
 				if err != nil {
-					log.Fatal().Msgf("Error when looking for StatefulSet: %s", err)
+					log.Fatal().Msgf("Error when searching for StatefulSet: %s", err)
 					return nil, err
 				}
 				return &spec.Items[0], nil
@@ -54,6 +111,55 @@ func ReturnStatefulSetObject(kubeConfigPath string, instanceOf string, namespace
 		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
 			log.Error().Msg("The StatefulSet was not created within the timeout period.")
 			return nil, errors.New("The StatefulSet was not created within the timeout period.")
+		}
+	}
+}
+
+// WaitForPodReady waits for a target Pod to become ready
+func WaitForPodReady(kubeConfigPath string, pod *v1.Pod, timeoutSeconds int64) (bool, error) {
+	clientset, err := GetClientSet(false, kubeConfigPath)
+	if err != nil {
+		return false, err
+	}
+
+	// Format list for metav1.ListOptions for watch
+	watchOptions := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf(
+			"metadata.name=%s", pod.Name),
+	}
+
+	// Create watch operation
+	objWatch, err := clientset.
+		CoreV1().
+		Pods(pod.ObjectMeta.Namespace).
+		Watch(context.Background(), watchOptions)
+	if err != nil {
+		log.Fatal().Msgf("Error when attempting to wait for Pod: %s", err)
+	}
+	log.Info().Msgf("Waiting for %s Pod to be ready. This could take up to %v seconds.", pod.Name, timeoutSeconds)
+
+	// Feed events using provided channel
+	objChan := objWatch.ResultChan()
+
+	// Listen until the Pod is ready
+	// Timeout if it isn't ready within timeoutSeconds
+	for {
+		select {
+		case event, ok := <-objChan:
+			if !ok {
+				// Error if the channel closes
+				log.Error().Msg("fail")
+			}
+			if event.
+				Object.(*v1.Pod).
+				Status.
+				Phase == "Running" {
+				log.Info().Msgf("Pod %s is %s.", pod.Name, event.Object.(*v1.Pod).Status.Phase)
+				return true, nil
+			}
+		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
+			log.Error().Msg("The operation timed out while waiting for the Pod to become ready.")
+			return false, errors.New("The operation timed out while waiting for the Pod to become ready.")
 		}
 	}
 }
@@ -68,8 +174,8 @@ func WaitForStatefulSetReady(kubeConfigPath string, statefulset *appsv1.Stateful
 	// Format list for metav1.ListOptions for watch
 	configuredReplicas := statefulset.Status.Replicas
 	watchOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf(
-			"app.kubernetes.io/instance=%s", statefulset.ObjectMeta.Name),
+		FieldSelector: fmt.Sprintf(
+			"metadata.name=%s", statefulset.Name),
 	}
 
 	// Create watch operation
@@ -80,7 +186,7 @@ func WaitForStatefulSetReady(kubeConfigPath string, statefulset *appsv1.Stateful
 	if err != nil {
 		log.Fatal().Msgf("Error when attempting to wait for StatefulSet: %s", err)
 	}
-	log.Info().Msgf("Waiting for StatefulSet %s to be ready. This could take up to %v seconds.", statefulset.Name, timeoutSeconds)
+	log.Info().Msgf("Waiting for %s StatefulSet to be ready. This could take up to %v seconds.", statefulset.Name, timeoutSeconds)
 
 	objChan := objWatch.ResultChan()
 	for {
@@ -89,11 +195,11 @@ func WaitForStatefulSetReady(kubeConfigPath string, statefulset *appsv1.Stateful
 			time.Sleep(time.Second * 1)
 			if !ok {
 				// Error if the channel closes
-				log.Fatal().Msgf("Error waiting StatefulSet: %s", err)
+				log.Fatal().Msgf("Error waiting for StatefulSet: %s", err)
 			}
 			if event.
 				Object.(*appsv1.StatefulSet).
-				Status.AvailableReplicas == configuredReplicas {
+				Status.ReadyReplicas == configuredReplicas {
 				log.Info().Msgf("All Pods in StatefulSet %s are ready.", statefulset.Name)
 				return true, nil
 			}


### PR DESCRIPTION
Signed-off-by: Scott Hawkins <scott@echoboomer.net>

Implements a few new Kubernetes functions for working with resources. I think moving forward this would be a better blueprint for handling similar issues versus parsing flags from the config.

```bash
2023-02-13T20:14 INF internal/k8s/exec.go:34 > Waiting for vault StatefulSet to be created.
2023-02-13T20:14 INF internal/k8s/exec.go:83 > Waiting for StatefulSet vault to be ready. This could take up to 60 seconds.
2023-02-13T20:14 INF internal/k8s/exec.go:97 > All Pods in StatefulSet vault are ready.
LOG: 2023/02/13 20:14:43.625777 /Users/scott/src/kubefirst/internal/k8s/portForward.go:94: Namespace for PF vault
LOG: 2023/02/13 20:14:43.626065 /Users/scott/src/kubefirst/internal/k8s/portForward.go:95: Name for PF vault-0
2023-02-13T20:14 INF internal/k8s/wrappers.go:169 > port forwarding is ready to get traffic
2023-02-13T20:14 INF internal/k8s/wrappers.go:172 > Pod "vault-0" at namespace "vault" has port-forward accepting local connections at port 8200
```