### PR TITLE
Bump Terraform version for local client use.

### DIFF
--- a/cmd/civo/validate.go
+++ b/cmd/civo/validate.go
@@ -168,7 +168,7 @@ func validateCivo(cmd *cobra.Command, args []string) error {
 	viper.Set("kubefirst.kubectl-client-version", "v1.23.15") // todo make configs like this more discoverable in struct?
 	viper.Set("kubefirst.kubefirst-config-path", fmt.Sprintf("%s/%s", homePath, ".kubefirst"))
 	viper.Set("kubefirst.terraform-client-path", fmt.Sprintf("%s/tools/terraform", k1Dir))
-	viper.Set("kubefirst.terraform-client-version", "1.0.11")
+	viper.Set("kubefirst.terraform-client-version", "1.3.8")
 	viper.Set("localhost.os", runtime.GOOS)
 	viper.Set("localhost.architecture", runtime.GOARCH)
 	viper.Set("github.atlantis.webhook.secret", pkg.Random(20))

--- a/configs/config.go
+++ b/configs/config.go
@@ -153,7 +153,7 @@ func ReadConfig() *Config {
 	config.K3dPath = fmt.Sprintf("%s/k3d", config.K1ToolsPath)
 	config.CertsPath = fmt.Sprintf("%s/ssl", config.K1FolderPath)
 	config.NgrokVersion = "v3"
-	config.TerraformVersion = "1.0.11"
+	config.TerraformVersion = "1.3.8"
 	config.ArgoCDChartHelmVersion = "4.10.5"
 	config.ArgoCDInitValuesYamlPath = fmt.Sprintf("%s/argocd-init-values.yaml", config.K1FolderPath)
 	// todo adopt latest helmVersion := "v3.9.0"

--- a/docs/tooling/tooling-overview.md
+++ b/docs/tooling/tooling-overview.md
@@ -8,16 +8,16 @@ There are a handful of utilities and CLIs that are needed to be successful on th
 ## Kubefirst Tooling
 
 | Utility       | Version | Link                          |
-|:--------------|:---------:|:-------------------------------|
-| Argo Workflow | 3.1.11   | [argo](argo.md)               |
-| ArgoCD        | 4.10.5   | [argocd](argocd.md)           |
+| :------------ | :-----: | :---------------------------- |
+| Argo Workflow | 3.1.11  | [argo](argo.md)               |
+| ArgoCD        | 4.10.5  | [argocd](argocd.md)           |
 | Atlantis      | 0.19.9  | [atlantis](atlantis.md)       |
 | AWS CLI       | 2.2.25  | [aws-cli](aws-cli.md)         |
 | Docker        | 20.10.7 | [docker](docker.md)           |
-| helm         |  3.6.1 | [helm](https://helm.sh/) |
-| k3d         |  5.4.6 | [k3d](https://k3d.io/) |
-| Kubectl       | 1.21.14  | [kubectl](kubectl.md)         |
-| Kubefirst     | 1.11.0   | [kubefirst](kubefirst-cli.md) |
-| ngrok         |  3       | [ngrok](ngrok.md)             |
-| Terraform     | 1.0.11   | [terraform](terraform.md)     |
-| Vault         | 1.11.2   | [vault-cli](vault-cli.md)     |
+| helm          |  3.6.1  | [helm](https://helm.sh/)      |
+| k3d           |  5.4.6  | [k3d](https://k3d.io/)        |
+| Kubectl       | 1.21.14 | [kubectl](kubectl.md)         |
+| Kubefirst     | 1.11.0  | [kubefirst](kubefirst-cli.md) |
+| ngrok         |    3    | [ngrok](ngrok.md)             |
+| Terraform     |  1.3.8  | [terraform](terraform.md)     |
+| Vault         | 1.11.2  | [vault-cli](vault-cli.md)     |


### PR DESCRIPTION
Addresses a bug where gitops repo webhook consistently failed. Also matches a recent update to the gitops-templates repo where we standardized github provider and terraform versions.