### PR TITLE
Fix bug in civo destroy workflow.

### DIFF
--- a/cmd/civo/destroy.go
+++ b/cmd/civo/destroy.go
@@ -60,7 +60,7 @@ func destroyCivo(cmd *cobra.Command, args []string) error {
 		log.Info().Msg("destroying civo resources with terraform")
 
 		clusterName := viper.GetString("flags.cluster-name")
-		kubeconfigPath := viper.GetString("k1-paths.kubeconfig")
+		kubeconfigPath := config.Kubeconfig
 		region := viper.GetString("flags.cloud-region")
 
 		client, err := civogo.NewClient(os.Getenv("CIVO_TOKEN"), region)
@@ -101,13 +101,13 @@ func destroyCivo(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		log.Info().Msgf("port-forward to argocd is available at %s", viper.GetString("components.argocd.port-forward-url"))
+		log.Info().Msgf("port-forward to argocd is available at %s", civo.ArgocdPortForwardURL)
 
 		customTransport := http.DefaultTransport.(*http.Transport).Clone()
 		customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		argocdHttpClient := http.Client{Transport: customTransport}
 		log.Info().Msg("deleting the registry application")
-		httpCode, _, err := argocd.DeleteApplication(&argocdHttpClient, config.RegistryYaml, argocdAuthToken, "true")
+		httpCode, _, err := argocd.DeleteApplication(&argocdHttpClient, config.RegistryAppName, argocdAuthToken, "true")
 		if err != nil {
 			return err
 		}

--- a/internal/argocd/argocd.go
+++ b/internal/argocd/argocd.go
@@ -112,7 +112,7 @@ func CreateApplication(httpClient pkg.HTTPDoer, cascade, applicationName, argoCD
 	params.Add("cascade", cascade)
 	paramBody := strings.NewReader(params.Encode())
 
-	url := fmt.Sprintf("%s/api/v1/applications/%s", viper.GetString("argocd.local.service"), applicationName)
+	url := fmt.Sprintf("%s/api/v1/applications/%s", GetArgoEndpoint(), applicationName)
 	log.Info().Msg(url)
 	req, err := http.NewRequest(http.MethodDelete, url, paramBody)
 	if err != nil {
@@ -153,7 +153,7 @@ func DeleteApplication(httpClient pkg.HTTPDoer, applicationName, argoCDToken, ca
 	params.Add("cascade", cascade)
 	paramBody := strings.NewReader(params.Encode())
 
-	url := fmt.Sprintf("%s/api/v1/applications/%s", viper.GetString("components.argocd.port-forward-url"), applicationName)
+	url := fmt.Sprintf("%s/api/v1/applications/%s", GetArgoEndpoint(), applicationName)
 	log.Info().Msg(url)
 	req, err := http.NewRequest(http.MethodDelete, url, paramBody)
 	if err != nil {
@@ -189,7 +189,7 @@ func DeleteApplication(httpClient pkg.HTTPDoer, applicationName, argoCDToken, ca
 
 func RefreshApplication(httpClient pkg.HTTPDoer, applicationName string, argoCDToken string) {
 
-	url := fmt.Sprintf("%s/api/v1/applications?refresh=true", viper.GetString("argocd.local.service"))
+	url := fmt.Sprintf("%s/api/v1/applications?refresh=true", GetArgoEndpoint())
 	log.Debug().Msg(url)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -215,7 +215,7 @@ func RefreshApplication(httpClient pkg.HTTPDoer, applicationName string, argoCDT
 
 func ListApplications(httpClient pkg.HTTPDoer, applicationName string, argoCDToken string) {
 
-	url := fmt.Sprintf("%s/api/v1/applications", viper.GetString("argocd.local.service"))
+	url := fmt.Sprintf("%s/api/v1/applications", GetArgoEndpoint())
 	log.Debug().Msg(url)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -242,7 +242,7 @@ func ListApplications(httpClient pkg.HTTPDoer, applicationName string, argoCDTok
 // Sync request ArgoCD to manual sync an application.
 func Sync(httpClient pkg.HTTPDoer, applicationName string, argoCDToken string) (httpCodeResponse int, syncStatus string, Error error) {
 
-	url := fmt.Sprintf("%s/api/v1/applications/%s/sync", viper.GetString("argocd.local.service"), applicationName)
+	url := fmt.Sprintf("%s/api/v1/applications/%s/sync", GetArgoEndpoint(), applicationName)
 	log.Info().Msg(url)
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
@@ -340,7 +340,7 @@ func GetArgocdAuthToken(dryRun bool) string {
 
 	time.Sleep(15 * time.Second)
 
-	url := fmt.Sprintf("%s/api/v1/session", viper.GetString("argocd.local.service"))
+	url := fmt.Sprintf("%s/api/v1/session", GetArgoEndpoint())
 
 	payload := strings.NewReader(fmt.Sprintf("{\n\t\"username\":\"admin\",\"password\":\"%s\"\n}", viper.GetString("argocd.admin.password")))
 
@@ -618,4 +618,16 @@ func GetArgoCDInitialCloudConfig(gitOpsRepo string, botPrivateKey string) Config
 	argoCDConfig.Configs.CredentialTemplates.SSHCreds.SSHPrivateKey = botPrivateKey
 
 	return argoCDConfig
+}
+
+// GetArgoEndpoint provides a solution in the interim for returning the correct
+// endpoint address
+func GetArgoEndpoint() string {
+	var argoCDLocalEndpoint string
+	if viper.GetString("argocd.local.service") != "" {
+		argoCDLocalEndpoint = viper.GetString("argocd.local.service")
+	} else {
+		argoCDLocalEndpoint = pkg.ArgocdPortForwardURL
+	}
+	return argoCDLocalEndpoint
 }

--- a/internal/civo/config.go
+++ b/internal/civo/config.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/caarlos0/env/v6"
+	"github.com/kubefirst/kubefirst/pkg"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 	TerraformClientVersion = "1.3.8"
 	ArgocdHelmChartVersion = "4.10.5"
 	ArgocdPortForwardURL   = "http://localhost:8080"
-	VaultPortForwardURL    = "http://localhost:8200"
+	VaultPortForwardURL    = pkg.ArgocdPortForwardURL
 )
 
 type CivoConfig struct {
@@ -40,6 +41,7 @@ type CivoConfig struct {
 	KubefirstConfig                 string
 	LogsDir                         string
 	MetaphorDir                     string
+	RegistryAppName                 string
 	RegistryYaml                    string
 	SSLBackupDir                    string
 	TerraformClient                 string
@@ -73,6 +75,7 @@ func GetConfig(clusterName string, domainName string, githubOwner string) *CivoC
 	config.KubefirstConfig = fmt.Sprintf("%s/.k1/%s", homeDir, ".kubefirst")
 	config.LogsDir = fmt.Sprintf("%s/.k1/logs", homeDir)
 	config.MetaphorDir = fmt.Sprintf("%s/.k1/metaphor-frontend", homeDir)
+	config.RegistryAppName = "registry"
 	config.RegistryYaml = fmt.Sprintf("%s/.k1/gitops/registry/%s/registry.yaml", homeDir, clusterName)
 	config.SSLBackupDir = fmt.Sprintf("%s/.k1/ssl/%s", homeDir, domainName)
 	config.TerraformClient = fmt.Sprintf("%s/.k1/tools/terraform", homeDir)

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -47,11 +47,12 @@ const (
 
 // Argo
 const (
-	ArgoPodName      = "argo-server"
-	ArgoNamespace    = "argo"
-	ArgoPodPort      = 2746
-	ArgoPodLocalPort = 2746
-	ArgoLocalURLTLS  = "https://argo.localdev.me"
+	ArgoPodName          = "argo-server"
+	ArgoNamespace        = "argo"
+	ArgoPodPort          = 2746
+	ArgoPodLocalPort     = 2746
+	ArgoLocalURLTLS      = "https://argo.localdev.me"
+	ArgocdPortForwardURL = "http://localhost:8080"
 )
 
 // ArgoCD


### PR DESCRIPTION
- Fixes ref to old kubeconfigpath viper entry.
- Adds func to return dynamic port forward url for Argo based on use.
- 