### PR TITLE
Add cloudregion flag to civo quota command, cleanup output.

### DIFF
--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -100,6 +100,7 @@ func Quota() *cobra.Command {
 		RunE:  evalCivoQuota,
 	}
 
+	quotaCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "NYC1", "the civo region to monitor quotas in")
 	quotaCmd.Flags().BoolVar(&quotaShowAllFlag, "show-all", false, "show all quotas regardless of usage")
 	return quotaCmd
 }

--- a/cmd/civo/quota.go
+++ b/cmd/civo/quota.go
@@ -61,7 +61,6 @@ type quotaFormattedOutput struct {
 // returnCivoQuotaEvaluation fetches quota from civo and compares limits to usage
 func returnCivoQuotaEvaluation(cloudRegion string, showAll bool) (string, int, int, error) {
 	// Fetch quota from civo
-
 	client, err := civogo.NewClient(os.Getenv("CIVO_TOKEN"), cloudRegion)
 	if err != nil {
 		log.Info().Msg(err.Error())
@@ -125,7 +124,7 @@ func returnCivoQuotaEvaluation(cloudRegion string, showAll bool) (string, int, i
 	}
 
 	// Parse the entire message
-	const messageHeader = "Civo Quota Health\n\nNote that if any of these are approaching their limits, you may want to increase them."
+	var messageHeader = fmt.Sprintf("Civo Quota Health\nRegion: %s\n\nNote that if any of these are approaching their limits, you may want to increase them.", cloudRegion)
 	sort.Strings(output)
 	result := printCivoQuotaWarning(messageHeader, output)
 
@@ -151,6 +150,9 @@ func printCivoQuotaWarning(messageHeader string, output []string) string {
 	createCivoQuotaWarning.WriteString("\n")
 	for _, result := range output {
 		createCivoQuotaWarning.WriteString(fmt.Sprintf("%s\n", result))
+	}
+	if len(output) == 0 {
+		createCivoQuotaWarning.WriteString("All quotas are healthy. To show all quotas regardless, run `kubefirst civo quota --show-all`\n")
 	}
 	createCivoQuotaWarning.WriteString("\nIf you encounter any errors while working with Civo, request a limit increase for your account before retrying.\n\n")
 	createCivoQuotaWarning.WriteString(civoQuotaIncreaseLink)


### PR DESCRIPTION
- The independent `civo quota` command can now be run by providing the cloud region flag or it defaults to NYC1 just like the top level command. This fixes an error where it wouldn't work if resources hadn't been deployed yet and the flag wasn't available via inheritance.
- States in the output now that quotas are healthy instead of just a blank line.

![image](https://user-images.githubusercontent.com/19732751/220694698-b2e31dc3-153c-40d4-b6ad-2bf9ca3bf241.png)

![image](https://user-images.githubusercontent.com/19732751/220694909-b7564f17-0ac1-47f3-addf-066135d4fafe.png)
