### PR TITLE
fix: UT

### DIFF
--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -948,7 +948,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		log.Info().Msgf("Error uploading to Minio bucket: %s", err)
 	}
 
-	log.Printf("Successfully uploaded %s to bucket %d\n", objectName, info.Bucket)
+	log.Printf("Successfully uploaded %s to bucket %s\n", objectName, info.Bucket)
 
 	//* vault port-forward
 	vaultStopChannel := make(chan struct{}, 1)

--- a/internal/gitlabcloud/gitlab.go
+++ b/internal/gitlabcloud/gitlab.go
@@ -28,7 +28,7 @@ func (gl *GitLabWrapper) AddSubGroupToGroup(subGroupID int, groupID int) error {
 		}
 		return err
 	}
-	log.Info().Msgf("subgroup %s added to group %s", subGroupID, group.Name)
+	log.Info().Msgf("subgroup %d added to group %s", subGroupID, group.Name)
 
 	return nil
 }


### PR DESCRIPTION
Solve UT issues: 
```bash 
internal/gitlabcloud/gitlab.go:31:2: (*github.com/rs/zerolog.Event).Msgf format %s has arg subGroupID of wrong type int
```

How it was validated: 
```
git_6za clone git@github.com:org-demo-6za-2/kubefirst.git main 
cd main 

docker run \
  -v  go-pkg:/go/pkg \
  -it --name kubefirst-main  \
  --dns="1.0.0.1" --dns="208.67.222.222" --dns="8.8.8.8" \
  -v $(PWD):/home/developer/app \
  --platform linux/amd64 \
  -e "TERM=xterm-256color" \
   6zar/cobra_dev

export ARTIFACT_SOURCE=`pwd`
go test ./...  --short -v

```

Results: 
```bash 
go test ./...  --short -v ; echo $?

?     github.com/kubefirst/kubefirst  [no test files]
?     github.com/kubefirst/kubefirst/cmd  [no test files]
?     github.com/kubefirst/kubefirst/cmd/civo [no test files]
?     github.com/kubefirst/kubefirst/cmd/k3d  [no test files]
?     github.com/kubefirst/kubefirst/cmd/local  [no test files]
?     github.com/kubefirst/kubefirst/configs  [no test files]
?     github.com/kubefirst/kubefirst/internal/addon [no test files]
=== RUN   TestArgoCDLivenessIntegration
    argocd_test.go:17: skipping integration test
--- SKIP: TestArgoCDLivenessIntegration (0.01s)
=== RUN   TestArgoWorkflowLivenessIntegration
    argocd_test.go:52: skipping integration test
--- SKIP: TestArgoWorkflowLivenessIntegration (0.00s)
PASS
ok    github.com/kubefirst/kubefirst/internal/argocd  (cached)
?     github.com/kubefirst/kubefirst/internal/argocdModel [no test files]
...
    ngrok_test.go:17: skipping end to tend test
--- SKIP: TestNgrokGitHubWebhookIntegration (0.00s)
=== RUN   TestVaultLoginEndToEnd
    vault_test.go:29: skipping end to tend test
--- SKIP: TestVaultLoginEndToEnd (0.00s)
PASS
ok    github.com/kubefirst/kubefirst/tests  (cached)
0

```