### PR TITLE
bugfix: fix error without git runner creation

### DIFF
--- a/cmd/civo/destroy.go
+++ b/cmd/civo/destroy.go
@@ -25,7 +25,7 @@ import (
 
 func destroyCivo(cmd *cobra.Command, args []string) error {
 	progressPrinter.AddTracker("preflight-checks", "Running preflight checks", 1)
-	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 4)
+	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 3)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)
 
 	log.Info().Msg("destroying kubefirst platform in civo")

--- a/cmd/civo/quota.go
+++ b/cmd/civo/quota.go
@@ -32,12 +32,17 @@ const (
 // All values used here must be of type int, excluding the string fields
 var checkFields map[string]string = map[string]string{
 	"cpu_core_limit":            "cpu_core_usage",
+	"database_count_limit":      "database_count_usage",
+	"database_cpu_core_limit":   "database_cpu_core_usage",
+	"database_ram_mb_limit":     "database_ram_mb_usage",
+	"database_disk_gb_limit":    "database_disk_gb_usage",
 	"disk_gb_limit":             "disk_gb_usage",
 	"disk_volume_count_limit":   "disk_volume_count_usage",
 	"instance_count_limit":      "instance_count_usage",
 	"loadbalancer_count_limit":  "loadbalancer_count_usage",
 	"network_count_limit":       "network_count_usage",
 	"objectstore_gb_limit":      "objectstore_gb_usage",
+	"port_count_limit":          "port_count_usage",
 	"public_ip_address_limit":   "public_ip_address_usage",
 	"ram_mb_limit":              "ram_mb_usage",
 	"security_group_limit":      "security_group_usage",

--- a/internal/civo/bootstrapSecrets.go
+++ b/internal/civo/bootstrapSecrets.go
@@ -23,14 +23,16 @@ func BootstrapCivoMgmtCluster(dryRun bool, kubeconfigPath string, gitProvider st
 	}
 
 	// Set git provider token value
-	var tokenValue, containerRegistryHost string
+	var containerRegistryHost, gitRunnerSecretName, tokenValue string
 	switch gitProvider {
 	case "github":
-		tokenValue = os.Getenv("GITHUB_TOKEN")
 		containerRegistryHost = "https://ghcr.io/"
+		gitRunnerSecretName = "controller-manager"
+		tokenValue = os.Getenv("GITHUB_TOKEN")
 	case "gitlab":
-		tokenValue = os.Getenv("GITLAB_TOKEN")
 		containerRegistryHost = "registry.gitlab.io"
+		gitRunnerSecretName = "gitlab-runner"
+		tokenValue = os.Getenv("GITLAB_TOKEN")
 	}
 
 	// Create namespace
@@ -143,7 +145,7 @@ func BootstrapCivoMgmtCluster(dryRun bool, kubeconfigPath string, gitProvider st
 		},
 		// git runner
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "controller-manager", Namespace: fmt.Sprintf("%s-runner", gitProvider)},
+			ObjectMeta: metav1.ObjectMeta{Name: gitRunnerSecretName, Namespace: fmt.Sprintf("%s-runner", gitProvider)},
 			Data: map[string][]byte{
 				fmt.Sprintf("%s_token", gitProvider): []byte(tokenValue),
 			},


### PR DESCRIPTION
- Fixes bug where secret name for git runner wasn't correct between the two providers.
- Fixes bug where destroy progress tracker didn't finish properly.
- Expands quota parameters checked for civo.