### PR TITLE
bugfix: github username missing from civo installer

### DIFF
--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -90,7 +90,7 @@ func Destroy() *cobra.Command {
 	destroyCmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "destroy the kubefirst platform",
-		Long:  "todo",
+		Long:  "destroy the kubefirst platform running in civo and remove all resources",
 		RunE:  destroyCivo,
 	}
 

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -150,7 +150,7 @@ func createCivo(cmd *cobra.Command, args []string) error {
 		cGitHost = civo.GitlabHost
 		cGitOwner = gitlabOwnerFlag
 		cGitToken = os.Getenv("GITLAB_TOKEN")
-		cGitUser = githubOwnerFlag
+		cGitUser = gitlabOwnerFlag
 		containerRegistryHost = "registry.gitlab.com"
 	default:
 		log.Error().Msgf("invalid git provider option")
@@ -907,7 +907,7 @@ func createCivo(cmd *cobra.Command, args []string) error {
 	case "github":
 		usernamePasswordString := fmt.Sprintf("%s:%s", cGitUser, cGitToken)
 		usernamePasswordStringB64 := base64.StdEncoding.EncodeToString([]byte(usernamePasswordString))
-		dockerConfigString := fmt.Sprintf(`{"auths": {"%s": {"username": "%s", "password": "%s", "email": "%s", "auth": "%s"}}}`, containerRegistryHost, cGitUser, cGitToken, "k-bot@example.com", usernamePasswordStringB64)
+		dockerConfigString := fmt.Sprintf(`{"auths": {"%s": {"username": "%s", "password": "%s", "email": "%s", "auth": "%s"}}}`, containerRegistryHost, viper.GetString("flags.github-owner"), cGitToken, "k-bot@example.com", usernamePasswordStringB64)
 
 		for _, repository := range createTokensFor {
 			// Create argo workflows pull secret


### PR DESCRIPTION
In its current state, the installer doesn't provide the github owner info which breaks auth for Docker push and pull.