### PR TITLE
feat: check for existing port forwards, delete gitlab groups

### DIFF
--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -108,6 +108,13 @@ func createCivo(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Check for existing port forwards before continuing
+	err = k8s.CheckForExistingPortForwards(8080, 8200, 9094)
+	if err != nil {
+		log.Fatal().Msgf("%s - this port is required to set up your kubefirst environment - please close any existing port forwards before continuing", err.Error())
+		return err
+	}
+
 	// required for destroy command
 	viper.Set("flags.alerts-email", alertsEmailFlag)
 	viper.Set("flags.cluster-name", clusterNameFlag)

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -97,6 +97,13 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Check for existing port forwards before continuing
+	err = k8s.CheckForExistingPortForwards(8080, 8200, 9094)
+	if err != nil {
+		log.Fatal().Msgf("%s - this port is required to set up your kubefirst environment - please close any existing port forwards before continuing", err.Error())
+		return err
+	}
+
 	// Global context
 	var ctx context.Context
 	ctx, cancelContext = context.WithCancel(context.Background())
@@ -105,7 +112,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 	httpClient := http.DefaultClient
 	segmentClient := &segment.Client
 	var segmentMsg string
-	
+
 	defer func(c segment.SegmentClient) {
 		err := c.Client.Close()
 		if err != nil {

--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -22,6 +22,13 @@ import (
 
 func destroyK3d(cmd *cobra.Command, args []string) error {
 
+	// Check for existing port forwards before continuing
+	err := k8s.CheckForExistingPortForwards(9000)
+	if err != nil {
+		log.Fatal().Msgf("%s - this port is required to tear down your kubefirst environment - please close any existing port forwards before continuing", err.Error())
+		return err
+	}
+
 	progressPrinter.AddTracker("preflight-checks", "Running preflight checks", 1)
 	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 2)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -1,0 +1,21 @@
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+// CheckForExistingPortForwards determines whether or not port forwards are already running
+// If so, a warning is issued
+func CheckForExistingPortForwards(ports ...int) error {
+	for _, port := range ports {
+		listen, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%v", port))
+		if err != nil {
+			return errors.New(fmt.Sprintf("port %v is in use", port))
+		}
+		_ = listen.Close()
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Adds check to k3d and civo to determine if ports are already in use that are required for port forwards. Exits if so.
- Attempts to delete GitLab subgroups, but this will only work on tiers below premium. It doesn't error out if it doesn't work, it just says to delete the group manually.