### PR TITLE
feat: update git flags, minor vault fixes

### DIFF
--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -13,8 +13,8 @@ var (
 	clusterNameFlag          string
 	clusterTypeFlag          string
 	dryRun                   bool
-	githubOwnerFlag          string
-	gitlabOwnerFlag          string
+	githubOrgFlag            string
+	gitlabGroupFlag          string
 	gitProviderFlag          string
 	gitopsTemplateURLFlag    string
 	gitopsTemplateBranchFlag string
@@ -72,8 +72,8 @@ func Create() *cobra.Command {
 	createCmd.MarkFlagRequired("domain-name")
 	createCmd.Flags().BoolVar(&dryRun, "dry-run", false, "don't execute the installation")
 	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %s", supportedGitProviders))
-	createCmd.Flags().StringVar(&githubOwnerFlag, "github-owner", "", "the GitHub owner of the new gitops and metaphor repositories - required if using github")
-	createCmd.Flags().StringVar(&gitlabOwnerFlag, "gitlab-owner", "", "the GitLab owner (group) of the new gitops and metaphor projects - required if using gitlab")
+	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - required if using github")
+	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
 	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "main", "the branch to clone for the gitops-template repository")
 	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/kubefirst/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
 	createCmd.Flags().StringVar(&kbotPasswordFlag, "kbot-password", "", "the default password to use for the kbot user")

--- a/cmd/k3d/command.go
+++ b/cmd/k3d/command.go
@@ -12,8 +12,8 @@ var (
 	clusterNameFlag          string
 	clusterTypeFlag          string
 	dryRun                   bool
-	githubOwnerFlag          string
-	gitlabOwnerFlag          string
+	githubUserFlag           string
+	gitlabGroupFlag          string
 	gitProviderFlag          string
 	gitopsTemplateURLFlag    string
 	gitopsTemplateBranchFlag string
@@ -71,8 +71,8 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
 	createCmd.Flags().BoolVar(&dryRun, "dry-run", false, "don't execute the installation")
 	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %s", supportedGitProviders))
-	createCmd.Flags().StringVar(&githubOwnerFlag, "github-owner", "", "the GitHub owner of the new gitops and metaphor repositories - required if using github")
-	createCmd.Flags().StringVar(&gitlabOwnerFlag, "gitlab-owner", "", "the GitLab owner (group) of the new gitops and metaphor projects - required if using gitlab")
+	createCmd.Flags().StringVar(&githubUserFlag, "github-user", "", "the GitHub user for the new gitops and metaphor repositories - required if using github and setting GITHUB_TOKEN, optional if using device auth")
+	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")
 	createCmd.Flags().StringVar(&gitopsTemplateBranchFlag, "gitops-template-branch", "main", "the branch to clone for the gitops-template repository")
 	createCmd.Flags().StringVar(&gitopsTemplateURLFlag, "gitops-template-url", "https://github.com/kubefirst/gitops-template.git", "the fully qualified url to the gitops-template repository to clone")
 	createCmd.Flags().StringVar(&kbotPasswordFlag, "kbot-password", "", "the default password to use for the kbot user")

--- a/internal/vault/autounseal.go
+++ b/internal/vault/autounseal.go
@@ -270,7 +270,7 @@ func (conf *VaultConfiguration) UnsealRaftFollowers(kubeConfigPath string) error
 		close(vaultStopChannel)
 
 		// Allow time between operations
-		time.Sleep(time.Second * 3)
+		time.Sleep(time.Second * 5)
 	}
 
 	return nil


### PR DESCRIPTION
- Updates `--github-owner` to `--github-user` for k3d.
- Updates `--github-owner` to `--github-org` for Civo.
- Updates `--gitlab-owner` to `--gitlab-group` for both.
- Adds progress printer for CoreDNS wait step for Civo to avoid no output while it waits.
- Adds some more wait logic to the Vault unseal process.

These commands were used for testing:

`go run . k3d create --git-provider gitlab --gitlab-group kubefirstdev`
`go run . k3d create --git-provider github --github-user echoboomer` (GITHUB_TOKEN set)
`go run . k3d create` (no GITHUB_TOKEN set)

```bash
go run . civo create \
    --alerts-email scott@kubeshop.io \
    --domain-name k-ray.space \
    --git-provider github \
    --github-org k-ray-space \
    --cluster-name k-ray-space
```

```bash
go run . civo create \
    --alerts-email scott@kubeshop.io \
    --domain-name k-ray.space \
    --git-provider gitlab \
    --gitlab-group kubefirstdev \
    --cluster-name k-ray-space
```