### PR TITLE
feat: gitlab username parse for setting GITLAB_USER

### DIFF
--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -193,7 +193,14 @@ func createCivo(cmd *cobra.Command, args []string) error {
 		cGitHost = civo.GitlabHost
 		cGitOwner = groupFullSlug
 		log.Info().Msgf("set gitlab owner to %s", groupFullSlug)
-		cGitUser = gitlabGroupFlag
+
+		// Get authenticated user's name
+		user, _, err := gl.Client.Users.CurrentUser()
+		if err != nil {
+			return errors.New("Unable to get authenticated user info.")
+		}
+		cGitUser = user.Username
+
 		containerRegistryHost = "registry.gitlab.com"
 		viper.Set("flags.gitlab-owner", gitlabGroupFlag)
 		viper.WriteConfig()

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -196,7 +196,14 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		cGitHost = k3d.GitlabHost
 		cGitOwner = groupFullSlug
 		log.Info().Msgf("set gitlab owner to %s", groupFullSlug)
-		cGitUser = gitlabGroupFlag
+
+		// Get authenticated user's name
+		user, _, err := gl.Client.Users.CurrentUser()
+		if err != nil {
+			return errors.New("Unable to get authenticated user info.")
+		}
+		cGitUser = user.Username
+
 		containerRegistryHost = "registry.gitlab.com"
 		viper.Set("flags.gitlab-owner", gitlabGroupFlag)
 	default:


### PR DESCRIPTION
Gets the currently authenticated user's username and sets that to `GITLAB_USER`.