### PR TITLE
fix: allow fetching argocd token over http

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"github.com/kubefirst/kubefirst/configs"
-	"github.com/kubefirst/kubefirst/internal/k3d"
-	"github.com/kubefirst/kubefirst/internal/segment"
-	"github.com/kubefirst/kubefirst/pkg"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -20,25 +15,6 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		segmentClient := &segment.Client
-
-		segmentMsg := segmentClient.SendCountMetric(configs.K1Version, k3d.CloudProvider, "defdef", "mgmt", k3d.DomainName, "bitbucket", "true", pkg.MetricInitStarted)
-		if segmentMsg != "" {
-			log.Info().Msg(segmentMsg)
-		}
-		segmentMsg = segmentClient.SendCountMetric(configs.K1Version, k3d.CloudProvider, "defdef", "mgmt", k3d.DomainName, "bitbucket", "true", pkg.MetricInitCompleted)
-		if segmentMsg != "" {
-			log.Info().Msg(segmentMsg)
-		}
-		segmentMsg = segmentClient.SendCountMetric(configs.K1Version, k3d.CloudProvider, "defdef", "mgmt", k3d.DomainName, "bitbucket", "true", pkg.MetricMgmtClusterInstallStarted)
-		if segmentMsg != "" {
-			log.Info().Msg(segmentMsg)
-		}
-		segmentMsg = segmentClient.SendCountMetric(configs.K1Version, k3d.CloudProvider, "defdef", "mgmt", k3d.DomainName, "bitbucket", "true", pkg.MetricMgmtClusterInstallCompleted)
-		if segmentMsg != "" {
-			log.Info().Msg(segmentMsg)
-		}
 
 		return nil
 	},

--- a/cmd/civo/destroy.go
+++ b/cmd/civo/destroy.go
@@ -314,7 +314,7 @@ func destroyCivo(cmd *cobra.Command, args []string) error {
 		}
 	}
 	time.Sleep(time.Second * 2) // allows progress bars to finish
-	fmt.Printf("Your kubefirst platform running in %s has been destroyed.", civo.CloudProvider)
+	fmt.Println(fmt.Sprintf("Your kubefirst platform running in %s has been destroyed.", civo.CloudProvider))
 
 	return nil
 }

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -902,6 +902,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 
 		log.Info().Msg("Getting an argocd auth token")
 		// todo return in here and pass argocdAuthToken as a parameter
+
 		token, err := argocd.GetArgocdTokenV2(httpClient, k3d.ArgocdURL, "admin", argocdPassword)
 		if err != nil {
 			return err

--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -266,7 +266,7 @@ func destroyK3d(cmd *cobra.Command, args []string) error {
 		}
 	}
 	time.Sleep(time.Millisecond * 200) // allows progress bars to finish
-	fmt.Printf("Your kubefirst platform running in %s has been destroyed.", k3d.CloudProvider)
+	fmt.Println(fmt.Sprintf("Your kubefirst platform running in %s has been destroyed.", k3d.CloudProvider))
 
 	return nil
 }

--- a/internal/argocd/argocd.go
+++ b/internal/argocd/argocd.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/internal/argocdModel"
+	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/viper"
 	yaml2 "gopkg.in/yaml.v2"
@@ -330,6 +331,11 @@ func GetArgoCDToken(username string, password string) (string, error) {
 
 // GetArgocdTokenV2
 func GetArgocdTokenV2(httpClient *http.Client, argocdBaseURL string, username string, password string) (string, error) {
+	err := helpers.TestEndpointTLS(argocdBaseURL)
+	if err != nil {
+		argocdBaseURL = strings.Replace(argocdBaseURL, "https://", "http://", 1)
+	}
+	log.Info().Msgf("using argocd url %s", argocdBaseURL)
 
 	url := argocdBaseURL + "/api/v1/session"
 

--- a/internal/helpers/tls.go
+++ b/internal/helpers/tls.go
@@ -1,0 +1,17 @@
+package helpers
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+)
+
+// TestEndpointTLS determines whether or not an endpoint accepts connections over https
+func TestEndpointTLS(endpoint string) error {
+	_, err := tls.Dial("tcp", fmt.Sprintf("%s:443", endpoint), nil)
+	if err != nil {
+		return errors.New(fmt.Sprintf("endpoint %s doesn't support tls: %s", endpoint, err))
+	}
+
+	return nil
+}

--- a/internal/reports/local.go
+++ b/internal/reports/local.go
@@ -87,7 +87,7 @@ func LocalHandoffScreenV2(argocdAdminPassword, clusterName, gitOwner string, con
 	handOffData.WriteString("\n--- Vault ")
 	handOffData.WriteString(strings.Repeat("-", 60))
 	handOffData.WriteString(fmt.Sprintf("\n URL: %s", k3d.VaultURL))
-	handOffData.WriteString(fmt.Sprintf("\n Root token: %s", "k1_local_vault_token"))
+	handOffData.WriteString("\n Root token: Check secret vault-unseal-secret in Namespace vault")
 	handOffData.WriteString("\n" + strings.Repeat("-", 70))
 
 	CommandSummary(handOffData)


### PR DESCRIPTION
This allows a user to still use the k3d/local one-liner install without needing to run `mkcert -install` prior to running anything. They can still optionally run `mkcert -install` (which is feedback given during handoff) to trust certs, but it won't break install.