### PR TITLE
fix: fix aws destroy logic

### DIFF
--- a/cmd/aws/create.go
+++ b/cmd/aws/create.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
+	"github.com/kubefirst/kubefirst/internal/reports"
 	"github.com/kubefirst/kubefirst/internal/segment"
 	"github.com/kubefirst/kubefirst/internal/services"
 	internalssh "github.com/kubefirst/kubefirst/internal/ssh"
@@ -1352,7 +1353,7 @@ func createAws(cmd *cobra.Command, args []string) error {
 	// Set flags used to track status of active options
 	helpers.SetCompletionFlags(awsinternal.CloudProvider, config.GitProvider)
 
-	//! reports.LocalHandoffScreenV2(argocdPassword, clusterNameFlag, cGitOwner, config, dryRunFlag, false)
+	reports.AwsHandoffScreen(viper.GetString("components.argocd.password"), clusterNameFlag, domainNameFlag, cGitOwner, config, dryRunFlag, false)
 
 	if useTelemetryFlag {
 		segmentMsg := segmentClient.SendCountMetric(configs.K1Version, awsinternal.CloudProvider, clusterId, clusterTypeFlag, domainNameFlag, gitProviderFlag, kubefirstTeam, pkg.MetricMgmtClusterInstallCompleted)

--- a/internal/reports/aws.go
+++ b/internal/reports/aws.go
@@ -1,0 +1,79 @@
+package reports
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	awsinternal "github.com/kubefirst/kubefirst/internal/aws"
+)
+
+// AwsHandoffScreen prints the handoff screen
+func AwsHandoffScreen(argocdAdminPassword, clusterName, domainName string, gitOwner string, config *awsinternal.AwsConfig, dryRun bool, silentMode bool) {
+	// prepare data for the handoff report
+	if dryRun {
+		log.Printf("[#99] Dry-run mode, LocalHandoffScreen skipped.")
+		return
+	}
+
+	if silentMode {
+		log.Printf("[#99] Silent mode enabled, LocalHandoffScreen skipped, please check ~/.kubefirst file for your cluster and service credentials.")
+		return
+	}
+
+	var handOffData bytes.Buffer
+
+	handOffData.WriteString(strings.Repeat("-", 70))
+	handOffData.WriteString("\n			!!! THIS TEXT BOX SCROLLS (use arrow keys) !!!")
+
+	handOffData.WriteString(fmt.Sprintf("\n\nCluster %q is up and running!:", clusterName))
+	handOffData.WriteString("\nThis information is available at $HOME/.kubefirst ")
+	handOffData.WriteString("\n")
+	handOffData.WriteString("\nPress ESC to leave this screen and return to your shell.")
+
+	handOffData.WriteString(fmt.Sprintf("\n\n--- %s ", caser.String(config.GitProvider)))
+	handOffData.WriteString(strings.Repeat("-", 59))
+	handOffData.WriteString(fmt.Sprintf("\n Owner: %s", gitOwner))
+	handOffData.WriteString("\n Repos: ")
+	handOffData.WriteString(fmt.Sprintf("\n  %s", config.DestinationGitopsRepoHttpsURL))
+	handOffData.WriteString(fmt.Sprintf("\n  %s", config.DestinationMetaphorRepoHttpsURL))
+
+	handOffData.WriteString("\n--- Kubefirst Console ")
+	handOffData.WriteString(strings.Repeat("-", 48))
+	handOffData.WriteString(fmt.Sprintf("\n URL: %s", "http://localhost:9094/services"))
+
+	handOffData.WriteString("\n--- ArgoCD ")
+	handOffData.WriteString(strings.Repeat("-", 59))
+	handOffData.WriteString(fmt.Sprintf("\n URL: https://argocd.%s", domainName))
+	handOffData.WriteString(fmt.Sprintf("\n username: %s", "admin"))
+	handOffData.WriteString(fmt.Sprintf("\n password: %s", argocdAdminPassword))
+
+	// handOffData.WriteString("\n--- Argo Workflows ")
+	// handOffData.WriteString(strings.Repeat("-", 51))
+	// handOffData.WriteString(fmt.Sprintf("\n URL: %s", k3d.ArgoWorkflowsURL))
+
+	// handOffData.WriteString("\n--- Atlantis ")
+	// handOffData.WriteString(strings.Repeat("-", 57))
+	// handOffData.WriteString(fmt.Sprintf("\n URL: %s", k3d.AtlantisURL))
+
+	// handOffData.WriteString("\n--- Chartmuseum ")
+	// handOffData.WriteString(strings.Repeat("-", 54))
+	// handOffData.WriteString(fmt.Sprintf("\n URL: %s", k3d.ChartMuseumURL))
+
+	// handOffData.WriteString("\n--- Metaphor ")
+	// handOffData.WriteString(strings.Repeat("-", 57))
+	// handOffData.WriteString("\n URLs: ")
+	// handOffData.WriteString(fmt.Sprintf("\n  %s", k3d.MetaphorDevelopmentURL))
+	// handOffData.WriteString(fmt.Sprintf("\n  %s", k3d.MetaphorStagingURL))
+	// handOffData.WriteString(fmt.Sprintf("\n  %s", k3d.MetaphorProductionURL))
+
+	handOffData.WriteString("\n--- Vault ")
+	handOffData.WriteString(strings.Repeat("-", 60))
+	handOffData.WriteString(fmt.Sprintf("\n URL: %s", fmt.Sprintf("https://vault.%s", domainName)))
+	handOffData.WriteString(fmt.Sprintf("\n Root token: %s", "Check the secret vault-unseal-secret in Namespace vault"))
+	handOffData.WriteString("\n" + strings.Repeat("-", 70))
+
+	CommandSummary(handOffData)
+}


### PR DESCRIPTION
Implements a function that removes all security groups associated with an EKS cluster as well as any ELBs associated with the cluster prior to `terraform destroy`.

Also implements handoff for AWS.