### PR TITLE
fix: enhance aws destroy functionality to fix terraform

### DIFF
--- a/cmd/civo/destroy.go
+++ b/cmd/civo/destroy.go
@@ -149,20 +149,6 @@ func destroyCivo(cmd *cobra.Command, args []string) error {
 			viper.WriteConfig()
 			log.Info().Msg("github resources terraform destroyed")
 
-			//// Since groups are only marked for deletion, attempt to remove them permanently
-			//// This only works on < premium tiers
-			//groupsToDelete := []string{"admins", "developers"}
-			//for _, group := range groupsToDelete {
-			//	gid, err := gitlabClient.GetGroupID(allgroups, group)
-			//	if err != nil {
-			//		log.Error().Msgf("could not get group id for group %s, skipping auto-remove: %s", group, err)
-			//	}
-			//	_, err = gitlabClient.Client.Groups.DeleteGroup(gid)
-			//	if err != nil {
-			//		log.Warn().Msgf("attempt to remove group %s (marked for deletion) failed - you will need to delete it manually: %s", group, err)
-			//	}
-			//}
-
 			progressPrinter.IncrementTracker("platform-destroy", 1)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/argoproj/argo-cd/v2 v2.6.5
+	github.com/argoproj/gitops-engine v0.7.1-0.20221208230615-917f5a0f16d5
 	github.com/aws/aws-sdk-go v1.44.213
 	github.com/aws/aws-sdk-go-v2/config v1.17.1
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.27
@@ -52,7 +53,6 @@ require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
-	github.com/argoproj/gitops-engine v0.7.1-0.20221208230615-917f5a0f16d5 // indirect
 	github.com/argoproj/pkg v0.13.7-0.20221221191914-44694015343d // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.9 // indirect

--- a/internal/argocd/applications.go
+++ b/internal/argocd/applications.go
@@ -1,0 +1,145 @@
+package argocd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	v1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	health "github.com/argoproj/gitops-engine/pkg/health"
+	"github.com/rs/zerolog/log"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	applicationDeletionTimeout int = 120
+)
+
+// ArgoCDApplicationCleanup removes and waits for specific ArgoCD applications
+func ArgoCDApplicationCleanup(clientset kubernetes.Interface, removeApps []string) error {
+	// Patch registry app to remove syncPolicy
+	removeSyncPolicyPatch, _ := json.Marshal(
+		[]PatchStringValue{{
+			Op:    "remove",
+			Path:  "/spec/syncPolicy",
+			Value: "",
+		}})
+	err := RestPatchArgoCD(clientset, "registry", removeSyncPolicyPatch)
+	if err != nil {
+		log.Warn().Msgf("could not remove syncPolicy from registry, it may already be disabled")
+	}
+	log.Info().Msgf("removed syncPolicy from registry application or it was already disabled")
+
+	// Patch dependent applications to remove syncPolicy}
+	for _, app := range removeApps {
+		log.Info().Msgf("attempting to delete argocd application %s", app)
+		err := waitForApplicationDeletion(clientset, app)
+		if err != nil {
+			log.Error().Msgf("error deleting argocd application %s: %s", err)
+		}
+	}
+
+	return nil
+}
+
+// deleteArgoCDApplicationV2 deletes an ArgoCD application
+func deleteArgoCDApplicationV2(clientset kubernetes.Interface, applicationName string, ch chan<- bool) error {
+	// Call the API to delete an ArgoCD application
+	data, err := clientset.CoreV1().RESTClient().Delete().
+		AbsPath(fmt.Sprintf("/apis/%s", ArgoCDAPIVersion)).
+		Namespace("argocd").
+		Resource("applications").
+		Name(applicationName).
+		DoRaw(context.Background())
+	if err != nil {
+		log.Error().Msgf("error deleting argocd application: %s", err)
+	}
+
+	// Unmarshal JSON API response to map[string]interface{}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		log.Error().Msgf("error deleting argocd application: %s", err)
+		return err
+	}
+	log.Info().Msgf("deleting %s: %s", applicationName, strings.ToLower(fmt.Sprintf("%v", resp["status"])))
+
+	for i := 0; i < applicationDeletionTimeout; i++ {
+		status, _ := returnArgoCDApplicationStatus(clientset, applicationName)
+		switch status {
+		case health.HealthStatusUnknown:
+			ch <- true
+			return nil
+		case health.HealthStatusMissing:
+			ch <- true
+			return nil
+		case health.HealthStatusProgressing:
+			log.Info().Msgf("application %s is progressing", applicationName)
+			continue
+		case health.HealthStatusDegraded:
+			log.Info().Msgf("application %s is progressing", applicationName)
+			continue
+		}
+		time.Sleep(time.Second * 1)
+	}
+
+	return nil
+}
+
+// returnArgoCDApplicationStatus returns the status details of a given ArgoCD application
+func returnArgoCDApplicationStatus(clientset kubernetes.Interface, applicationName string) (health.HealthStatusCode, error) {
+	// Call the API to return an ArgoCD application object
+	data, err := clientset.CoreV1().RESTClient().Get().
+		AbsPath(fmt.Sprintf("/apis/%s", ArgoCDAPIVersion)).
+		Namespace("argocd").
+		Resource("applications").
+		Name(applicationName).
+		DoRaw(context.Background())
+	if err != nil {
+		log.Error().Msgf("error retrieving argocd applications: %s", err)
+		return health.HealthStatusUnknown, err
+	}
+
+	// Unmarshal JSON API response to map[string]interface{}
+	var resp *v1alpha1.Application
+	if err := json.Unmarshal(data, &resp); err != nil {
+		log.Error().Msgf("error converting argocd application data: %s", err)
+		return health.HealthStatusUnknown, err
+	}
+	status := resp.Status.Health.Status
+
+	return status, nil
+}
+
+// waitForApplicationDeletion disables sync and deletes specific applications
+// from ArgoCD before continuing
+func waitForApplicationDeletion(clientset kubernetes.Interface, applicationName string) error {
+	ch := make(chan bool)
+	// Patch app to remove sync
+	removeSyncPolicyPatch, _ := json.Marshal(
+		[]PatchStringValue{{
+			Op:    "remove",
+			Path:  "/spec/syncPolicy",
+			Value: "",
+		}})
+	err := RestPatchArgoCD(clientset, applicationName, removeSyncPolicyPatch)
+	if err != nil {
+		log.Info().Msgf("error patching argocd application %s: %s", applicationName, err)
+	}
+	log.Info().Msgf("removed syncPolicy from argocd application %s or it was not present", applicationName)
+
+	// Delete applications and wait for them to report as deleted
+	go deleteArgoCDApplicationV2(clientset, applicationName, ch)
+	for {
+		select {
+		case deleted, ok := <-ch:
+			if !ok || deleted {
+				fmt.Printf("deleted argocd application %s if it existed\n", applicationName)
+				return nil
+			}
+		case <-time.After(time.Duration(applicationDeletionTimeout) * time.Second):
+			return fmt.Errorf("timed out waiting for argocd application %s to delete", applicationName)
+		}
+	}
+}

--- a/internal/argocd/rest.go
+++ b/internal/argocd/rest.go
@@ -1,0 +1,28 @@
+package argocd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// RestPatchArgoCD uses RESTClient to patch a given ArgoCD Application using the provided payload
+func RestPatchArgoCD(clientset kubernetes.Interface, applicationName string, payload []byte) error {
+	// Call the API to patch the resource
+	_, err := clientset.CoreV1().RESTClient().Patch(types.JSONPatchType).
+		AbsPath(fmt.Sprintf("/apis/%s", ArgoCDAPIVersion)).
+		Namespace("argocd").
+		Resource("applications").
+		Name(applicationName).
+		Body(payload).
+		DoRaw(context.Background())
+	if err != nil {
+		return err
+	}
+	log.Info().Msgf("patched %s successfully", applicationName)
+
+	return nil
+}

--- a/internal/argocd/types.go
+++ b/internal/argocd/types.go
@@ -1,0 +1,10 @@
+package argocd
+
+const ArgoCDAPIVersion string = "argoproj.io/v1alpha1"
+
+// PatchStringValue specifies a patch operation for a string
+type PatchStringValue struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}

--- a/internal/argocd/util.go
+++ b/internal/argocd/util.go
@@ -40,7 +40,7 @@ func WaitForJobComplete(clientset *kubernetes.Clientset, job *batchv1.Job, timeo
 		case event, ok := <-objChan:
 			if !ok {
 				// Error if the channel closes
-				log.Error().Msg("fail")
+				log.Error().Msgf("failed to wait for job %s to complete", job.Name)
 			}
 			if event.
 				Object.(*batchv1.Job).

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -60,7 +60,7 @@ func NewGitLabClient(token string, parentGroupName string) (GitLabWrapper, error
 	}, nil
 }
 
-// CheckProjectExists
+// CheckProjectExists within a parent group
 func (gl *GitLabWrapper) CheckProjectExists(projectName string) (bool, error) {
 	allprojects, err := gl.GetProjects()
 	if err != nil {
@@ -75,17 +75,6 @@ func (gl *GitLabWrapper) CheckProjectExists(projectName string) (bool, error) {
 	}
 
 	return exists, nil
-}
-
-// GetGroupID
-func (gl *GitLabWrapper) GetGroupID(groups []gitlab.Group, groupName string) (int, error) {
-	for _, g := range groups {
-		if g.Name == groupName {
-			return g.ID, nil
-		}
-	}
-
-	return 0, fmt.Errorf("group %s not found", groupName)
 }
 
 // GetProjectID returns a project's ID scoped to the parent group


### PR DESCRIPTION
Fixes aws destroys by removing critical applications first that have external dependencies. This prevents a race condition where terraform destroy operations would fail.