### PR TITLE
feat: remove civo creds if specific fields fail to parse

### DIFF
--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -325,15 +325,26 @@ func createCivo(cmd *cobra.Command, args []string) error {
 		}
 
 		// Verify all credentials fields are present
+		var civoCredsFailureMessage string
 		switch {
 		case creds.AccessKeyID == "":
-			return fmt.Errorf("when retrieving civo access credentials, AccessKeyID was empty - please retry your cluster creation")
+			civoCredsFailureMessage = "when retrieving civo access credentials, AccessKeyID was empty - please retry your cluster creation"
 		case creds.ID == "":
-			return fmt.Errorf("when retrieving civo access credentials, ID was empty - please retry your cluster creation")
+			civoCredsFailureMessage = "when retrieving civo access credentials, ID was empty - please retry your cluster creation"
 		case creds.Name == "":
-			return fmt.Errorf("when retrieving civo access credentials, Name was empty - please retry your cluster creation")
+			civoCredsFailureMessage = "when retrieving civo access credentials, Name was empty - please retry your cluster creation"
 		case creds.SecretAccessKeyID == "":
-			return fmt.Errorf("when retrieving civo access credentials, SecretAccessKeyID was empty - please retry your cluster creation")
+			civoCredsFailureMessage = "when retrieving civo access credentials, SecretAccessKeyID was empty - please retry your cluster creation"
+		}
+		if civoCredsFailureMessage != "" {
+			// Creds failed to properly parse, so remove them
+			err := civo.DeleteAccessCredentials(kubefirstStateStoreBucketName, cloudRegionFlag)
+			if err != nil {
+				return err
+			}
+
+			// Return error
+			return fmt.Errorf(civoCredsFailureMessage)
 		}
 
 		viper.Set("kubefirst.state-store-creds.access-key-id", creds.AccessKeyID)

--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kubefirst/kubefirst/internal/github"
 	gitlab "github.com/kubefirst/kubefirst/internal/gitlab"
-	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/internal/k3d"
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
@@ -23,13 +22,13 @@ import (
 func destroyK3d(cmd *cobra.Command, args []string) error {
 	// Determine if there are active installs
 	gitProvider := viper.GetString("flags.git-provider")
-	_, err := helpers.EvalDestroy(k3d.CloudProvider, gitProvider)
-	if err != nil {
-		return err
-	}
+	// _, err := helpers.EvalDestroy(k3d.CloudProvider, gitProvider)
+	// if err != nil {
+	// 	return err
+	// }
 
 	// Check for existing port forwards before continuing
-	err = k8s.CheckForExistingPortForwards(9000)
+	err := k8s.CheckForExistingPortForwards(9000)
 	if err != nil {
 		log.Fatal().Msgf("%s - this port is required to tear down your kubefirst environment - please close any existing port forwards before continuing", err.Error())
 		return err

--- a/internal/civo/objectStorage.go
+++ b/internal/civo/objectStorage.go
@@ -34,24 +34,45 @@ func GetAccessCredentials(credentialName, region string) (civogo.ObjectStoreCred
 	if err != nil {
 		log.Info().Msg(err.Error())
 	}
-	
+
 	if creds == (civogo.ObjectStoreCredential{}) {
 		log.Info().Msgf("credential name: %s not found, creating", credentialName)
 		creds, err = createAccessCredentials(credentialName, region)
 		if err != nil {
 			return civogo.ObjectStoreCredential{}, err
 		}
-	
+
 		creds, err = getAccessCredentials(creds.ID, region)
 		if err != nil {
 			return civogo.ObjectStoreCredential{}, err
 		}
-	
+
 		log.Info().Msgf("created object storage credential %s", credentialName)
 		return creds, nil
 	}
 
 	return creds, nil
+}
+
+func DeleteAccessCredentials(credentialName, region string) error {
+
+	client, err := civogo.NewClient(os.Getenv("CIVO_TOKEN"), region)
+	if err != nil {
+		log.Info().Msg(err.Error())
+		return err
+	}
+
+	creds, err := checkKubefirstCredentials(credentialName, region)
+	if err != nil {
+		log.Info().Msg(err.Error())
+	}
+
+	_, err = client.DeleteObjectStoreCredential(creds.ID)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func checkKubefirstCredentials(credentialName, region string) (civogo.ObjectStoreCredential, error) {


### PR DESCRIPTION
Adds a conditional check that returns an error and removes created credentials if any of the fields in the request to get Civo credentials are empty.

Also comments out the pre-destroy check for k3d.