### PR TITLE
remove duplicate output from destroy

### DIFF
--- a/cmd/aws/destroy.go
+++ b/cmd/aws/destroy.go
@@ -76,7 +76,7 @@ func destroyAws(cmd *cobra.Command, args []string) error {
 	}
 	progressPrinter.IncrementTracker("preflight-checks", 1)
 
-	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 2)
+	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 3)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)
 
 	switch gitProvider {

--- a/cmd/civo/destroy.go
+++ b/cmd/civo/destroy.go
@@ -77,7 +77,7 @@ func destroyCivo(cmd *cobra.Command, args []string) error {
 	}
 	progressPrinter.IncrementTracker("preflight-checks", 1)
 
-	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 2)
+	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 3)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)
 
 	switch gitProvider {

--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -35,7 +35,7 @@ func destroyK3d(cmd *cobra.Command, args []string) error {
 	}
 
 	progressPrinter.AddTracker("preflight-checks", "Running preflight checks", 1)
-	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 2)
+	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 3)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)
 
 	log.Info().Msg("destroying kubefirst platform running in k3d")


### PR DESCRIPTION
trying to remove duplication of this message on destroy
<img width="801" alt="image" src="https://user-images.githubusercontent.com/3649336/227958290-7ee4d6d4-92e6-4961-8423-9e539faa3491.png">

looks like there's 3 refs for this categoty - adjusting in hopes this will accommodate
<img width="740" alt="image" src="https://user-images.githubusercontent.com/3649336/227958589-f74ab653-f3c3-46b0-a8fe-968a6a9ac3b0.png">
