### PR TITLE
feat: root-credentials command

### DIFF
--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -38,7 +38,7 @@ func NewCommand() *cobra.Command {
 	civoCmd.SilenceUsage = true
 
 	// wire up new commands
-	civoCmd.AddCommand(BackupSSL(), Create(), Destroy(), Quota())
+	civoCmd.AddCommand(BackupSSL(), Create(), Destroy(), Quota(), RootCredentials())
 
 	return civoCmd
 }
@@ -104,4 +104,15 @@ func Quota() *cobra.Command {
 	quotaCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "NYC1", "the civo region to monitor quotas in")
 
 	return quotaCmd
+}
+
+func RootCredentials() *cobra.Command {
+	authCmd := &cobra.Command{
+		Use:   "root-credentials",
+		Short: "retrieve root authentication information for platform components",
+		Long:  "retrieve root authentication information for platform components",
+		RunE:  getCivoRootCredentials,
+	}
+
+	return authCmd
 }

--- a/cmd/civo/root-credentials.go
+++ b/cmd/civo/root-credentials.go
@@ -1,0 +1,38 @@
+package civo
+
+import (
+	"fmt"
+
+	"github.com/kubefirst/kubefirst/internal/civo"
+	"github.com/kubefirst/kubefirst/internal/helpers"
+	"github.com/kubefirst/kubefirst/internal/k8s"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func getCivoRootCredentials(cmd *cobra.Command, args []string) error {
+	clusterName := viper.GetString("flags.cluster-name")
+	domainName := viper.GetString("flags.domain-name")
+	gitProvider := viper.GetString("flags.git-provider")
+	gitOwner := viper.GetString(fmt.Sprintf("flags.%s-owner", gitProvider))
+
+	// Determine if there are active installs
+	_, err := helpers.EvalAuth(civo.CloudProvider, gitProvider)
+	if err != nil {
+		return err
+	}
+
+	// Instantiate kubernetes client
+	config := civo.GetConfig(clusterName, domainName, gitProvider, gitOwner)
+	clientset, err := k8s.GetClientSet(false, config.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	err = helpers.ParseAuthData(clientset, civo.CloudProvider, gitProvider)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/k3d/command.go
+++ b/cmd/k3d/command.go
@@ -37,7 +37,7 @@ func NewCommand() *cobra.Command {
 	k3dCmd.SilenceUsage = true
 
 	// wire up new commands
-	k3dCmd.AddCommand(Create(), Destroy())
+	k3dCmd.AddCommand(Create(), Destroy(), RootCredentials())
 
 	return k3dCmd
 }
@@ -54,7 +54,7 @@ func LocalCommandAlias() *cobra.Command {
 	localCmd.SilenceUsage = true
 
 	// wire up new commands
-	localCmd.AddCommand(Create(), Destroy())
+	localCmd.AddCommand(Create(), Destroy(), RootCredentials())
 
 	return localCmd
 }
@@ -91,4 +91,15 @@ func Destroy() *cobra.Command {
 	}
 
 	return destroyCmd
+}
+
+func RootCredentials() *cobra.Command {
+	authCmd := &cobra.Command{
+		Use:   "root-credentials",
+		Short: "retrieve root authentication information for platform components",
+		Long:  "retrieve root authentication information for platform components",
+		RunE:  getK3dRootCredentials,
+	}
+
+	return authCmd
 }

--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -35,7 +35,7 @@ func destroyK3d(cmd *cobra.Command, args []string) error {
 	}
 
 	progressPrinter.AddTracker("preflight-checks", "Running preflight checks", 1)
-	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 3)
+	progressPrinter.AddTracker("platform-destroy", "Destroying your kubefirst platform", 2)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)
 
 	log.Info().Msg("destroying kubefirst platform running in k3d")

--- a/cmd/k3d/root-credentials.go
+++ b/cmd/k3d/root-credentials.go
@@ -1,0 +1,36 @@
+package k3d
+
+import (
+	"fmt"
+
+	"github.com/kubefirst/kubefirst/internal/helpers"
+	"github.com/kubefirst/kubefirst/internal/k3d"
+	"github.com/kubefirst/kubefirst/internal/k8s"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func getK3dRootCredentials(cmd *cobra.Command, args []string) error {
+	gitProvider := viper.GetString("flags.git-provider")
+	gitOwner := viper.GetString(fmt.Sprintf("flags.%s-owner", gitProvider))
+
+	// Determine if there are active installs
+	_, err := helpers.EvalAuth(k3d.CloudProvider, gitProvider)
+	if err != nil {
+		return err
+	}
+
+	// Instantiate kubernetes client
+	config := k3d.GetConfig(gitProvider, gitOwner)
+	clientset, err := k8s.GetClientSet(false, config.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	err = helpers.ParseAuthData(clientset, k3d.CloudProvider, gitProvider)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -44,7 +44,7 @@ func NewGitLabClient(token string, parentGroupName string) (GitLabWrapper, error
 		}
 	}
 	if gid == 0 {
-		return GitLabWrapper{}, fmt.Errorf("error: could not find gitlab group %s", parentGroupName)
+		return GitLabWrapper{}, fmt.Errorf("could not find gitlab group %s", parentGroupName)
 	}
 
 	// Get parent group path

--- a/internal/helpers/destroy.go
+++ b/internal/helpers/destroy.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog/log"
@@ -16,16 +15,14 @@ func EvalDestroy(expectedCloudProvider string, expectedGitProvider string) (bool
 	setupComplete := viper.GetBool("kubefirst.setup-complete")
 
 	if !setupComplete {
-		return false, errors.New(
-			fmt.Sprintf(
-				"There are no active kubefirst platforms to destroy.\n\tTo get started, run: kubefirst %s create -h\n",
-				expectedCloudProvider,
-			),
+		return false, fmt.Errorf(
+			"There are no active kubefirst platforms to destroy.\n\tTo get started, run: kubefirst %s create -h\n",
+			expectedCloudProvider,
 		)
 	}
 
 	if cloudProvider == "" || gitProvider == "" {
-		return false, errors.New("Could not parse cloud and git provider information from config.")
+		return false, fmt.Errorf("could not parse cloud and git provider information from config")
 	}
 	log.Info().Msgf("Verified %s platform using %s - continuing with destroy...", expectedCloudProvider, expectedGitProvider)
 

--- a/internal/helpers/root-credentials.go
+++ b/internal/helpers/root-credentials.go
@@ -1,0 +1,106 @@
+package helpers
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kubefirst/kubefirst/internal/k8s"
+	"github.com/kubefirst/kubefirst/internal/reports"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+	"k8s.io/client-go/kubernetes"
+)
+
+// EvalAuth determines whether or not there are active kubefirst platforms
+// If there are not, an error is returned
+func EvalAuth(expectedCloudProvider string, expectedGitProvider string) (bool, error) {
+	flags := GetCompletionFlags()
+
+	if !flags.SetupComplete {
+		return false, fmt.Errorf(
+			"There are no active kubefirst platforms to retrieve credentials for.\n\tTo get started, run: kubefirst %s create -h\n",
+			expectedCloudProvider,
+		)
+	}
+
+	switch {
+	case flags.CloudProvider == "" || flags.GitProvider == "":
+		return false, fmt.Errorf("could not parse cloud and git provider information from config")
+	case flags.CloudProvider != expectedCloudProvider:
+		return false, fmt.Errorf("it looks like the current deployed platform is %s - try running this command for that provider", flags.CloudProvider)
+	}
+
+	log.Info().Msgf("Verified %s platform using %s - parsing credentials...", expectedCloudProvider, expectedGitProvider)
+
+	return true, nil
+}
+
+// ParseAuthData gets base root credentials for platform components
+func ParseAuthData(clientset *kubernetes.Clientset, cloudProvider string, gitProvider string) error {
+	// Retrieve vault root token
+	var vaultRootToken string
+	vaultUnsealSecretData, err := k8s.ReadSecretV2(clientset, "vault", "vault-unseal-secret")
+	if err != nil {
+		log.Warn().Msgf("vault secret may not exist: %s", err)
+	}
+	if len(vaultUnsealSecretData) != 0 {
+		vaultRootToken = vaultUnsealSecretData["root-token"]
+	}
+
+	// Retrieve argocd password
+	var argoCDPassword string
+	argoCDSecretData, err := k8s.ReadSecretV2(clientset, "argocd", "argocd-initial-admin-secret")
+	if err != nil {
+		return err
+	}
+	argoCDPassword = argoCDSecretData["password"]
+
+	// Retrieve kbot password
+	kbotPassword := viper.GetString("kbot.password")
+
+	// Format parameters for final output
+	params := make(map[string]string)
+	paramsSorted := make(map[string]string)
+
+	// Each item from the objects above should be added to params
+	params["ArgoCD Admin Password"] = argoCDPassword
+	params["KBot User Password"] = kbotPassword
+
+	if vaultRootToken != "" {
+		params["Vault Root Token"] = vaultRootToken
+	}
+
+	// Sort
+	paramKeys := make([]string, 0, len(params))
+	for k := range params {
+		paramKeys = append(paramKeys, k)
+	}
+	sort.Strings(paramKeys)
+	for _, k := range paramKeys {
+		paramsSorted[k] = params[k]
+	}
+
+	messageHeader := fmt.Sprintf("%s Authentication\n\nKeep this data secure. These passwords can be used to access the following applications in your platform.", cloudProvider)
+	message := printAuthData(messageHeader, params)
+	fmt.Println(reports.StyleMessage(message))
+
+	return nil
+}
+
+// printAuthData provides visual output detailing authentication data for k3d
+func printAuthData(messageHeader string, params map[string]string) string {
+	var createAuthData bytes.Buffer
+	createAuthData.WriteString(strings.Repeat("-", 70))
+	createAuthData.WriteString(fmt.Sprintf("\n%s\n", messageHeader))
+	createAuthData.WriteString(strings.Repeat("-", 70))
+	createAuthData.WriteString("\n\n")
+
+	for object, auth := range params {
+		createAuthData.WriteString(fmt.Sprintf("%s: %s\n\n", object, auth))
+	}
+
+	return createAuthData.String()
+
+}

--- a/internal/helpers/setup.go
+++ b/internal/helpers/setup.go
@@ -9,3 +9,12 @@ func SetCompletionFlags(cloudProvider string, gitProvider string) {
 	viper.Set("kubefirst.setup-complete", true)
 	viper.WriteConfig()
 }
+
+// GetCompletionFlags gets specific config flags to mark status of an install
+func GetCompletionFlags() CompletionFlags {
+	return CompletionFlags{
+		CloudProvider: viper.GetString("kubefirst.cloud-provider"),
+		GitProvider:   viper.GetString("kubefirst.git-provider"),
+		SetupComplete: viper.GetBool("kubefirst.setup-complete"),
+	}
+}

--- a/internal/helpers/types.go
+++ b/internal/helpers/types.go
@@ -1,0 +1,7 @@
+package helpers
+
+type CompletionFlags struct {
+	CloudProvider string
+	GitProvider   string
+	SetupComplete bool
+}

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -2,16 +2,14 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -21,7 +19,6 @@ import (
 
 // CreateSecretV2 creates a Kubernetes Secret
 func CreateSecretV2(clientset *kubernetes.Clientset, secret *v1.Secret) error {
-
 	_, err := clientset.CoreV1().Secrets(secret.Namespace).Create(
 		context.Background(),
 		secret,
@@ -30,7 +27,7 @@ func CreateSecretV2(clientset *kubernetes.Clientset, secret *v1.Secret) error {
 	if err != nil {
 		return err
 	}
-	log.Info().Msgf("Created Secret %s in Namespace %s\n", secret.Name, secret.Namespace)
+	log.Info().Msgf("created Secret %s in Namespace %s\n", secret.Name, secret.Namespace)
 	return nil
 }
 
@@ -55,10 +52,9 @@ func ReadConfigMapV2(kubeConfigPath string, namespace string, configMapName stri
 
 // ReadSecretV2 reads the content of a Kubernetes Secret
 func ReadSecretV2(clientset *kubernetes.Clientset, namespace string, secretName string) (map[string]string, error) {
-
 	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
 	if err != nil {
-		log.Error().Msgf("Error getting secret: %s\n", err)
+		log.Error().Msgf("error getting secret: %s\n", err)
 		return map[string]string{}, nil
 	}
 
@@ -79,7 +75,7 @@ func ReadService(kubeConfigPath string, namespace string, serviceName string) (*
 
 	service, err := clientset.CoreV1().Services(namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
 	if err != nil {
-		log.Error().Msgf("Error getting Service: %s\n", err)
+		log.Error().Msgf("error getting Service: %s\n", err)
 		return &v1.Service{}, nil
 	}
 
@@ -127,17 +123,17 @@ func podExec(kubeConfigPath string, ps *PodSessionOptions, pe v1.PodExecOptions,
 	// POST op against Kubernetes API to initiate remote command
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
 	if err != nil {
-		log.Fatal().Msgf("Error executing command on Pod: %s", err)
+		log.Fatal().Msgf("error executing command on Pod: %s", err)
 		return err
 	}
 
 	// Put the terminal into raw mode to prevent it echoing characters twice
-	oldState, err := terminal.MakeRaw(0)
+	oldState, err := term.MakeRaw(0)
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to start terminal: %s", err)
+		log.Fatal().Msgf("error when attempting to start terminal: %s", err)
 		return err
 	}
-	defer terminal.Restore(0, oldState)
+	defer term.Restore(0, oldState)
 
 	var showOutput io.Writer
 	if silent {
@@ -152,14 +148,13 @@ func podExec(kubeConfigPath string, ps *PodSessionOptions, pe v1.PodExecOptions,
 		Tty:    ps.TtyEnabled,
 	})
 	if err != nil {
-		log.Fatal().Msgf("Error running command on Pod: %s", err)
+		log.Fatal().Msgf("error running command on Pod: %s", err)
 	}
 	return nil
 }
 
 // ReturnDeploymentObject returns a matching appsv1.Deployment object based on the filters
 func ReturnDeploymentObject(clientset *kubernetes.Clientset, matchLabel string, matchLabelValue string, namespace string, timeoutSeconds float64) (*appsv1.Deployment, error) {
-
 	// Filter
 	deploymentListOptions := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", matchLabel, matchLabelValue),
@@ -171,9 +166,9 @@ func ReturnDeploymentObject(clientset *kubernetes.Clientset, matchLabel string, 
 		Deployments(namespace).
 		Watch(context.Background(), deploymentListOptions)
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to search for Deployment: %s", err)
+		log.Fatal().Msgf("error when attempting to search for Deployment: %s", err)
 	}
-	log.Info().Msgf("waiting for %s Deployment to be created.", matchLabelValue)
+	log.Info().Msgf("waiting for %s Deployment to be created", matchLabelValue)
 
 	objChan := objWatch.ResultChan()
 	for {
@@ -182,7 +177,7 @@ func ReturnDeploymentObject(clientset *kubernetes.Clientset, matchLabel string, 
 			time.Sleep(time.Second * 1)
 			if !ok {
 				// Error if the channel closes
-				log.Fatal().Msgf("Error waiting for %s Deployment to be created: %s", matchLabelValue, err)
+				log.Fatal().Msgf("error waiting for %s Deployment to be created: %s", matchLabelValue, err)
 			}
 			if event.
 				Object.(*appsv1.Deployment).Status.Replicas > 0 {
@@ -218,9 +213,9 @@ func ReturnPodObject(kubeConfigPath string, matchLabel string, matchLabelValue s
 		Pods(namespace).
 		Watch(context.Background(), podListOptions)
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to search for Pod: %s", err)
+		log.Fatal().Msgf("error when attempting to search for Pod: %s", err)
 	}
-	log.Info().Msgf("waiting for %s Pod to be created.", matchLabelValue)
+	log.Info().Msgf("waiting for %s Pod to be created", matchLabelValue)
 
 	objChan := objWatch.ResultChan()
 	for {
@@ -229,13 +224,13 @@ func ReturnPodObject(kubeConfigPath string, matchLabel string, matchLabelValue s
 			time.Sleep(time.Second * 1)
 			if !ok {
 				// Error if the channel closes
-				log.Fatal().Msgf("Error waiting for %s Pod to be created: %s", matchLabelValue, err)
+				log.Fatal().Msgf("error waiting for %s Pod to be created: %s", matchLabelValue, err)
 			}
 			if event.
 				Object.(*v1.Pod).Status.Phase == "Pending" {
 				spec, err := clientset.CoreV1().Pods(namespace).List(context.Background(), podListOptions)
 				if err != nil {
-					log.Fatal().Msgf("Error when searching for Pod: %s", err)
+					log.Fatal().Msgf("error when searching for Pod: %s", err)
 					return nil, err
 				}
 				return &spec.Items[0], nil
@@ -244,13 +239,13 @@ func ReturnPodObject(kubeConfigPath string, matchLabel string, matchLabelValue s
 				Object.(*v1.Pod).Status.Phase == "Running" {
 				spec, err := clientset.CoreV1().Pods(namespace).List(context.Background(), podListOptions)
 				if err != nil {
-					log.Fatal().Msgf("Error when searching for Pod: %s", err)
+					log.Fatal().Msgf("error when searching for Pod: %s", err)
 					return nil, err
 				}
 				return &spec.Items[0], nil
 			}
 		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
-			log.Error().Msg("The Pod was not created within the timeout period")
+			log.Error().Msg("the Pod was not created within the timeout period")
 			return nil, fmt.Errorf("the Pod was not created within the timeout period")
 		}
 	}
@@ -269,7 +264,7 @@ func ReturnStatefulSetObject(clientset *kubernetes.Clientset, matchLabel string,
 		StatefulSets(namespace).
 		Watch(context.Background(), statefulSetListOptions)
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to search for StatefulSet: %s", err)
+		log.Fatal().Msgf("error when attempting to search for StatefulSet: %s", err)
 	}
 	log.Info().Msgf("waiting for %s StatefulSet to be created using label %s=%s", matchLabelValue, matchLabel, matchLabelValue)
 
@@ -286,13 +281,13 @@ func ReturnStatefulSetObject(clientset *kubernetes.Clientset, matchLabel string,
 				Object.(*appsv1.StatefulSet).Status.Replicas > 0 {
 				spec, err := clientset.AppsV1().StatefulSets(namespace).List(context.Background(), statefulSetListOptions)
 				if err != nil {
-					log.Fatal().Msgf("Error when searching for StatefulSet: %s", err)
+					log.Fatal().Msgf("error when searching for StatefulSet: %s", err)
 					return nil, err
 				}
 				return &spec.Items[0], nil
 			}
 		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
-			log.Error().Msg("The StatefulSet was not created within the timeout period")
+			log.Error().Msg("the StatefulSet was not created within the timeout period")
 			return nil, fmt.Errorf("the StatefulSet was not created within the timeout period")
 		}
 	}
@@ -300,7 +295,6 @@ func ReturnStatefulSetObject(clientset *kubernetes.Clientset, matchLabel string,
 
 // WaitForDeploymentReady waits for a target Deployment to become ready
 func WaitForDeploymentReady(clientset *kubernetes.Clientset, deployment *appsv1.Deployment, timeoutSeconds int64) (bool, error) {
-
 	// Format list for metav1.ListOptions for watch
 	configuredReplicas := deployment.Status.Replicas
 	watchOptions := metav1.ListOptions{
@@ -314,9 +308,9 @@ func WaitForDeploymentReady(clientset *kubernetes.Clientset, deployment *appsv1.
 		Deployments(deployment.ObjectMeta.Namespace).
 		Watch(context.Background(), watchOptions)
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to wait for Deployment: %s", err)
+		log.Fatal().Msgf("error when attempting to wait for Deployment: %s", err)
 	}
-	log.Info().Msgf("waiting for %s Deployment to be ready. This could take up to %v seconds.", deployment.Name, timeoutSeconds)
+	log.Info().Msgf("waiting for %s Deployment to be ready - this could take up to %v seconds", deployment.Name, timeoutSeconds)
 
 	objChan := objWatch.ResultChan()
 	for {
@@ -325,17 +319,17 @@ func WaitForDeploymentReady(clientset *kubernetes.Clientset, deployment *appsv1.
 			time.Sleep(time.Second * 1)
 			if !ok {
 				// Error if the channel closes
-				log.Fatal().Msgf("Error waiting for Deployment: %s", err)
+				log.Fatal().Msgf("error waiting for Deployment: %s", err)
 			}
 			if event.
 				Object.(*appsv1.Deployment).
 				Status.ReadyReplicas == configuredReplicas {
-				log.Info().Msgf("All Pods in Deployment %s are ready.", deployment.Name)
+				log.Info().Msgf("all Pods in Deployment %s are ready", deployment.Name)
 				return true, nil
 			}
 		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
-			log.Error().Msg("The Deployment was not ready within the timeout period")
-			return false, errors.New("The Deployment was not ready within the timeout period")
+			log.Error().Msg("the Deployment was not ready within the timeout period")
+			return false, fmt.Errorf("the Deployment was not ready within the timeout period")
 		}
 	}
 }
@@ -354,9 +348,9 @@ func WaitForPodReady(clientset *kubernetes.Clientset, pod *v1.Pod, timeoutSecond
 		Pods(pod.ObjectMeta.Namespace).
 		Watch(context.Background(), watchOptions)
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to wait for Pod: %s", err)
+		log.Fatal().Msgf("error when attempting to wait for Pod: %s", err)
 	}
-	log.Info().Msgf("waiting for %s Pod to be ready. This could take up to %v seconds.", pod.Name, timeoutSeconds)
+	log.Info().Msgf("waiting for %s Pod to be ready - this could take up to %v seconds", pod.Name, timeoutSeconds)
 
 	// Feed events using provided channel
 	objChan := objWatch.ResultChan()
@@ -378,15 +372,14 @@ func WaitForPodReady(clientset *kubernetes.Clientset, pod *v1.Pod, timeoutSecond
 				return true, nil
 			}
 		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
-			log.Error().Msg("The operation timed out while waiting for the Pod to become ready")
-			return false, errors.New("The operation timed out while waiting for the Pod to become ready")
+			log.Error().Msg("the operation timed out while waiting for the Pod to become ready")
+			return false, fmt.Errorf("the operation timed out while waiting for the Pod to become ready")
 		}
 	}
 }
 
 // WaitForStatefulSetReady waits for a target StatefulSet to become ready
 func WaitForStatefulSetReady(clientset *kubernetes.Clientset, statefulset *appsv1.StatefulSet, timeoutSeconds int64, ignoreReady bool) (bool, error) {
-
 	// Format list for metav1.ListOptions for watch
 	configuredReplicas := statefulset.Status.Replicas
 
@@ -396,9 +389,9 @@ func WaitForStatefulSetReady(clientset *kubernetes.Clientset, statefulset *appsv
 			"metadata.name=%s", statefulset.Name),
 	})
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to wait for StatefulSet: %s", err)
+		log.Fatal().Msgf("error when attempting to wait for StatefulSet: %s", err)
 	}
-	log.Info().Msgf("waiting for %s StatefulSet to be ready. This could take up to %v seconds.", statefulset.Name, timeoutSeconds)
+	log.Info().Msgf("waiting for %s StatefulSet to be ready - this could take up to %v seconds", statefulset.Name, timeoutSeconds)
 
 	objChan := objWatch.ResultChan()
 	for {
@@ -407,7 +400,7 @@ func WaitForStatefulSetReady(clientset *kubernetes.Clientset, statefulset *appsv
 			time.Sleep(time.Second * 1)
 			if !ok {
 				// Error if the channel closes
-				log.Fatal().Msgf("Error waiting for StatefulSet: %s", err)
+				log.Fatal().Msgf("error waiting for StatefulSet: %s", err)
 			}
 			if ignoreReady {
 				// Under circumstances where Pods may be running but not ready
@@ -443,8 +436,8 @@ func WaitForStatefulSetReady(clientset *kubernetes.Clientset, statefulset *appsv
 				}
 			}
 		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
-			log.Error().Msg("The StatefulSet was not ready within the timeout period")
-			return false, errors.New("The StatefulSet was not ready within the timeout period")
+			log.Error().Msg("the StatefulSet was not ready within the timeout period")
+			return false, fmt.Errorf("the StatefulSet was not ready within the timeout period")
 		}
 	}
 }
@@ -458,7 +451,7 @@ func watchForStatefulSetPodReady(clientset *kubernetes.Clientset, namespace stri
 			"metadata.name=%s", podName),
 	})
 	if err != nil {
-		log.Fatal().Msgf("Error when attempting to wait for Pod: %s", err)
+		log.Fatal().Msgf("error when attempting to wait for Pod: %s", err)
 	}
 
 	podObjChan := podObjWatch.ResultChan()
@@ -468,15 +461,15 @@ func watchForStatefulSetPodReady(clientset *kubernetes.Clientset, namespace stri
 			time.Sleep(time.Second * 1)
 			if !ok {
 				// Error if the channel closes
-				log.Fatal().Msgf("Error waiting for Pod: %s", err)
+				log.Fatal().Msgf("error waiting for Pod: %s", err)
 			}
-			if podEvent.Object.(*corev1.Pod).Status.Phase == "Running" {
+			if podEvent.Object.(*v1.Pod).Status.Phase == "Running" {
 				podObjWatch.Stop()
 				return nil
 			}
 		case <-time.After(time.Duration(timeoutSeconds) * time.Second):
-			log.Error().Msg("The StatefulSet Pod was not ready within the timeout period")
-			return errors.New("The StatefulSet Pod was not ready within the timeout period")
+			log.Error().Msg("the StatefulSet Pod was not ready within the timeout period")
+			return fmt.Errorf("the StatefulSet Pod was not ready within the timeout period")
 		}
 	}
 }

--- a/internal/k8s/kubernetes.go
+++ b/internal/k8s/kubernetes.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/viper"
@@ -20,14 +19,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var gitlabToolboxPodName string
-
 var GitlabSecretClient coreV1Types.SecretInterface
-
-type secret struct {
-	namespace string
-	name      string
-}
 
 type PatchJson struct {
 	Op   string `json:"op"`
@@ -150,37 +142,4 @@ func WaitForNamespaceandPods(dryRun bool, kubeconfigPath, kubectlClientPath, nam
 	} else {
 		log.Info().Msg("soft-serve is ready, skipping")
 	}
-}
-
-// CreateSecret creates a key for a specific namespace.
-//
-//	namespace: namespace where secret will be created
-//	secretName: secret name to be stored at a Kubernetes object
-//	data: a single or collection of []bytes that will be stored as a Kubernetes secret
-func CreateSecret(kubeconfigPath, namespace, secretName string, data map[string][]byte) error {
-
-	// todo: method
-	clientset, err := GetClientSet(false, kubeconfigPath)
-	if err != nil {
-		return err
-	}
-
-	secret := v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-		},
-		Data: data,
-	}
-
-	_, err = clientset.CoreV1().Secrets(namespace).Create(
-		context.Background(),
-		&secret,
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/internal/k8s/wrappers.go
+++ b/internal/k8s/wrappers.go
@@ -27,7 +27,6 @@ import (
 //		wg.Done()
 //	}()
 func OpenPortForwardPodWrapper(clientset *kubernetes.Clientset, restConfig *rest.Config, podName, namespace string, podPort int, podLocalPort int, stopChannel chan struct{}) {
-
 	// readyCh communicate when the port forward is ready to get traffic
 	readyCh := make(chan struct{})
 
@@ -64,12 +63,11 @@ func OpenPortForwardPodWrapper(clientset *kubernetes.Clientset, restConfig *rest
 		log.Info().Msg("port forwarding is ready to get traffic")
 	}
 
-	log.Info().Msgf("Pod %q at namespace %q has port-forward accepting local connections at port %d\n", podName, namespace, podLocalPort)
+	log.Info().Msgf("pod %q at namespace %q has port-forward accepting local connections at port %d\n", podName, namespace, podLocalPort)
 
 }
 
 func OpenPortForwardServiceWrapper(kubeconfigPath, kubeconfigClientPath, namespace, serviceName string, servicePort int, serviceLocalPort int, stopChannel chan struct{}) {
-
 	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		log.Error().Err(err).Msg("")
@@ -114,6 +112,5 @@ func OpenPortForwardServiceWrapper(kubeconfigPath, kubeconfigClientPath, namespa
 		log.Info().Msg("port forwarding is ready to get traffic")
 	}
 
-	log.Info().Msgf("Service %q at namespace %q has port-forward accepting local connections at port %d\n", serviceName, namespace, serviceLocalPort)
-	return
+	log.Info().Msgf("service %q at namespace %q has port-forward accepting local connections at port %d\n", serviceName, namespace, serviceLocalPort)
 }


### PR DESCRIPTION
syntax cleanup and fixing static check errors as well.

only implements `root-credentials` for `k3d` and `civo` for now