### PR TITLE
fix: move logging hint to func, reduce where called

### DIFF
--- a/cmd/aws/create.go
+++ b/cmd/aws/create.go
@@ -43,6 +43,7 @@ import (
 )
 
 func createAws(cmd *cobra.Command, args []string) error {
+	helpers.DisplayLogHints()
 
 	progressPrinter.AddTracker("preflight-checks", "Running preflight checks", 3)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)
@@ -1305,14 +1306,14 @@ func createAws(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.Error().Err(err).Msg("")
 	}
-	
+
 	if useTelemetryFlag {
 		segmentMsg := segmentClient.SendCountMetric(configs.K1Version, awsinternal.CloudProvider, clusterId, clusterTypeFlag, domainNameFlag, gitProviderFlag, kubefirstTeam, pkg.MetricMgmtClusterInstallCompleted)
 		if segmentMsg != "" {
 			log.Info().Msg(segmentMsg)
 		}
 	}
-	
+
 	// Set flags used to track status of active options
 	helpers.SetCompletionFlags(awsinternal.CloudProvider, config.GitProvider)
 

--- a/cmd/aws/destroy.go
+++ b/cmd/aws/destroy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubefirst/kubefirst/internal/argocd"
 	awsinternal "github.com/kubefirst/kubefirst/internal/aws"
 	gitlab "github.com/kubefirst/kubefirst/internal/gitlab"
+	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 	"github.com/kubefirst/kubefirst/internal/terraform"
@@ -25,6 +26,8 @@ import (
 )
 
 func destroyAws(cmd *cobra.Command, args []string) error {
+	helpers.DisplayLogHints()
+
 	// Determine if there are active installs
 	gitProvider := viper.GetString("flags.git-provider")
 	cloudRegionFlag := viper.GetString("flags.cloud-region")

--- a/cmd/civo/backup.go
+++ b/cmd/civo/backup.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/kubefirst/kubefirst/internal/civo"
+	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/internal/ssl"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -11,6 +12,8 @@ import (
 )
 
 func backupCivoSSL(cmd *cobra.Command, args []string) error {
+	helpers.DisplayLogHints()
+
 	clusterName := viper.GetString("flags.cluster-name")
 	domainName := viper.GetString("flags.domain-name")
 	gitProvider := viper.GetString("flags.git-provider")

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -38,6 +38,7 @@ import (
 )
 
 func createCivo(cmd *cobra.Command, args []string) error {
+	helpers.DisplayLogHints()
 
 	progressPrinter.AddTracker("preflight-checks", "Running preflight checks", 6)
 	progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)

--- a/cmd/civo/destroy.go
+++ b/cmd/civo/destroy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubefirst/kubefirst/internal/argocd"
 	"github.com/kubefirst/kubefirst/internal/civo"
 	gitlab "github.com/kubefirst/kubefirst/internal/gitlab"
+	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 	"github.com/kubefirst/kubefirst/internal/terraform"
@@ -24,6 +25,8 @@ import (
 )
 
 func destroyCivo(cmd *cobra.Command, args []string) error {
+	helpers.DisplayLogHints()
+
 	// Determine if there are active installs
 	gitProvider := viper.GetString("flags.git-provider")
 	// _, err := helpers.EvalDestroy(civo.CloudProvider, gitProvider)

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -47,6 +47,7 @@ var (
 )
 
 func runK3d(cmd *cobra.Command, args []string) error {
+	helpers.DisplayLogHints()
 
 	clusterNameFlag, err := cmd.Flags().GetString("cluster-name")
 	if err != nil {
@@ -1319,7 +1320,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 			log.Info().Msg(segmentMsg)
 		}
 	}
-	
+
 	// Set flags used to track status of active options
 	helpers.SetCompletionFlags(k3d.CloudProvider, config.GitProvider)
 

--- a/cmd/k3d/destroy.go
+++ b/cmd/k3d/destroy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubefirst/kubefirst/internal/github"
 	gitlab "github.com/kubefirst/kubefirst/internal/gitlab"
+	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/internal/k3d"
 	"github.com/kubefirst/kubefirst/internal/k8s"
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
@@ -20,6 +21,8 @@ import (
 )
 
 func destroyK3d(cmd *cobra.Command, args []string) error {
+	helpers.DisplayLogHints()
+
 	// Determine if there are active installs
 	gitProvider := viper.GetString("flags.git-provider")
 	// _, err := helpers.EvalDestroy(k3d.CloudProvider, gitProvider)

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kubefirst/kubefirst/internal/helpers"
 	"github.com/kubefirst/kubefirst/internal/progressPrinter"
 	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/rs/zerolog/log"
@@ -18,6 +19,8 @@ var resetCmd = &cobra.Command{
 	Short: "removes local kubefirst content to provision a new platform",
 	Long:  "removes local kubefirst content to provision a new platform",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		helpers.DisplayLogHints()
+
 		progressPrinter.AddTracker("removing-platform-content", "Removing local platform content", 2)
 		progressPrinter.SetupProgress(progressPrinter.TotalOfTrackers(), false)
 

--- a/internal/helpers/setup.go
+++ b/internal/helpers/setup.go
@@ -1,13 +1,19 @@
 package helpers
 
-import "github.com/spf13/viper"
+import (
+	"fmt"
+	"strings"
 
-// SetCompletionFlags sets specific config flags to mark status of an install
-func SetCompletionFlags(cloudProvider string, gitProvider string) {
-	viper.Set("kubefirst.cloud-provider", cloudProvider)
-	viper.Set("kubefirst.git-provider", gitProvider)
-	viper.Set("kubefirst.setup-complete", true)
-	viper.WriteConfig()
+	"github.com/spf13/viper"
+)
+
+// DisplayLogHints prints info to the terminal regarding log streaming
+func DisplayLogHints() {
+	logFile := viper.GetString("k1-paths.log-file")
+
+	fmt.Println(strings.Repeat("-", 48))
+	fmt.Printf("Follow your logs in a new terminal with: \n   tail -f -n +1 %s \n", logFile)
+	fmt.Println(strings.Repeat("-", 48))
 }
 
 // GetCompletionFlags gets specific config flags to mark status of an install
@@ -17,4 +23,12 @@ func GetCompletionFlags() CompletionFlags {
 		GitProvider:   viper.GetString("kubefirst.git-provider"),
 		SetupComplete: viper.GetBool("kubefirst.setup-complete"),
 	}
+}
+
+// SetCompletionFlags sets specific config flags to mark status of an install
+func SetCompletionFlags(cloudProvider string, gitProvider string) {
+	viper.Set("kubefirst.cloud-provider", cloudProvider)
+	viper.Set("kubefirst.git-provider", gitProvider)
+	viper.Set("kubefirst.setup-complete", true)
+	viper.WriteConfig()
 }

--- a/main.go
+++ b/main.go
@@ -45,14 +45,6 @@ func main() {
 	logfile := fmt.Sprintf("%s/log_%d.log", logsFolder, epoch)
 	//fmt.Printf("Logging at: %s \n", logfile)
 
-	// Avoid printing log helper for certain subcommands
-	var excludeLogHelperFrom []string = []string{"version"}
-	if len(os.Args) > 1 && !pkg.FindStringInSlice(excludeLogHelperFrom, os.Args[1]) {
-		fmt.Printf("\n-----------\n")
-		fmt.Printf("Follow your logs in a new terminal with: \n   tail -f -n +1 %s \n", logfile)
-		fmt.Printf("\n-----------\n")
-	}
-
 	file, err := pkg.OpenLogFile(logfile)
 	if err != nil {
 		stdLog.Panicf("unable to store log location, error is: %s", err)
@@ -82,6 +74,7 @@ func main() {
 	}
 
 	viper.Set("k1-paths.logs-dir", logsFolder)
+	viper.Set("k1-paths.log-file", fmt.Sprintf("%s/log_%d.log", logsFolder, epoch))
 	err = viper.WriteConfig()
 	if err != nil {
 		stdLog.Panicf("unable to set log-file-location, error is: %s", err)


### PR DESCRIPTION
logging hint will come directly from `cmd/` subdirs from now on and will only show up on things like `create`, `destroy`, etc. this avoids the hint dropping on things like `--help`, etc.