### PR TITLE
fix: allow destroy civo/aws tf on tf fail

### DIFF
--- a/cmd/aws/create.go
+++ b/cmd/aws/create.go
@@ -814,6 +814,9 @@ func createAws(cmd *cobra.Command, args []string) error {
 
 		err := terraform.InitApplyAutoApprove(dryRunFlag, tfEntrypoint, tfEnvs)
 		if err != nil {
+			viper.Set("kubefirst-checks.terraform-apply-aws-failed", true)
+			viper.WriteConfig()
+
 			return fmt.Errorf("error creating aws resources with terraform %s : %s", tfEntrypoint, err)
 		}
 

--- a/cmd/civo/create.go
+++ b/cmd/civo/create.go
@@ -834,6 +834,9 @@ func createCivo(cmd *cobra.Command, args []string) error {
 		tfEnvs = civo.GetCivoTerraformEnvs(tfEnvs)
 		err := terraform.InitApplyAutoApprove(dryRunFlag, tfEntrypoint, tfEnvs)
 		if err != nil {
+			viper.Set("kubefirst-checks.terraform-apply-civo-failed", true)
+			viper.WriteConfig()
+
 			return fmt.Errorf("error creating civo resources with terraform %s : %s", tfEntrypoint, err)
 		}
 

--- a/cmd/civo/destroy.go
+++ b/cmd/civo/destroy.go
@@ -161,7 +161,7 @@ func destroyCivo(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if viper.GetBool("kubefirst-checks.terraform-apply-civo") {
+	if viper.GetBool("kubefirst-checks.terraform-apply-civo") || viper.GetBool("kubefirst-checks.terraform-apply-civo-failed") {
 		kcfg := k8s.CreateKubeConfig(false, config.Kubeconfig)
 
 		log.Info().Msg("destroying civo resources with terraform")


### PR DESCRIPTION
as configured, running `destroy` for either `aws` or `civo` won't destroy cloud resources if that apply step failed. this fixes that.