### PR TITLE
Fix disable browser open

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/kubefirst/kubefirst/cmd"
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/viper"
@@ -84,5 +83,10 @@ func main() {
 		stdLog.Panicf("unable to set log-file-location, error is: %s", err)
 	}
 
-	cmd.Execute()
+	//cmd.Execute()
+	err = pkg.OpenBrowser("https://www.google.com")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(err)
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/kubefirst/kubefirst/cmd"
 	"github.com/kubefirst/kubefirst/configs"
 	"github.com/kubefirst/kubefirst/pkg"
 	"github.com/spf13/viper"
@@ -83,10 +84,5 @@ func main() {
 		stdLog.Panicf("unable to set log-file-location, error is: %s", err)
 	}
 
-	//cmd.Execute()
-	err = pkg.OpenBrowser("https://www.google.com")
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(err)
+	cmd.Execute()
 }

--- a/pkg/helpers.go
+++ b/pkg/helpers.go
@@ -365,25 +365,27 @@ func InformUser(message string, silentMode bool) {
 }
 
 // OpenBrowser opens the browser with the given URL
+// At this time, support is limited to darwin platforms
 func OpenBrowser(url string) error {
-	var err error
-
 	switch runtime.GOOS {
 	case "linux":
-		if err = exec.Command("xdg-open", url).Start(); err != nil {
-			return err
-		}
+		//if err = exec.Command("xdg-open", url).Start(); err != nil {
+		//	return err
+		//}
+		return nil
 	case "windows":
-		if err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start(); err != nil {
-			return err
-		}
+		//if err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start(); err != nil {
+		//	return err
+		//}
+		return nil
 	case "darwin":
-		if err = exec.Command("open", url).Start(); err != nil {
-			return err
+		if err := exec.Command("open", url).Start(); err != nil {
+			log.Warn().Msgf("unable to load the browser - continuing")
+			return nil
 		}
 	default:
-		err = fmt.Errorf("unable to load the browser, unsupported platform")
-		return err
+		log.Warn().Msgf("unable to load the browser, unsupported platform - continuing")
+		return nil
 	}
 
 	return nil


### PR DESCRIPTION
With these changes, the `OpenBrowser` func never returns anything other than `nil`. If there is an error, it is one of either:

`2023-04-11T10:44 WRN pkg/helpers.go:387 > unable to load the browser, unsupported platform - continuing`

`2023-04-11T10:44 WRN pkg/helpers.go:387 > unable to load the browser - continuing`

This will prevent failed installs due to the inability to open the browser. The user can get the link to the console from the report at the end.