### PR TITLE
Git protocol opinion

### DIFF
--- a/cmd/k3d/command.go
+++ b/cmd/k3d/command.go
@@ -25,6 +25,7 @@ var (
 	gitProviderFlag          string
 	gitopsTemplateURLFlag    string
 	gitopsTemplateBranchFlag string
+	gitProtocolFlag          string
 	useTelemetryFlag         bool
 
 	// RootCredentials
@@ -34,6 +35,9 @@ var (
 
 	// Supported git providers
 	supportedGitProviders = []string{"github", "gitlab"}
+
+	// Supported git providers
+	supportedGitProtocolOverride = []string{"https", "ssh"}
 )
 
 func NewCommand() *cobra.Command {
@@ -74,6 +78,7 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
 	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
 	createCmd.Flags().StringVar(&gitProviderFlag, "git-provider", "github", fmt.Sprintf("the git provider - one of: %s", supportedGitProviders))
+	createCmd.Flags().StringVar(&gitProtocolFlag, "git-protocol", "ssh", fmt.Sprintf("the git provider - one of: %s (default is ssh)", supportedGitProtocolOverride))
 	createCmd.Flags().StringVar(&githubUserFlag, "github-user", "", "the GitHub user for the new gitops and metaphor repositories - this cannot be used with --github-org")
 	createCmd.Flags().StringVar(&githubOrgFlag, "github-org", "", "the GitHub organization for the new gitops and metaphor repositories - this cannot be used with --github-user")
 	createCmd.Flags().StringVar(&gitlabGroupFlag, "gitlab-group", "", "the GitLab group for the new gitops and metaphor projects - required if using gitlab")

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -1214,8 +1214,8 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		log.Info().Msg("configuring vault with terraform")
 
 		tfEnvs["TF_VAR_email_address"] = "your@email.com"
-		tfEnvs[fmt.Sprintf("TF_VAR_%s_token", config.GitProvider)] = cGitToken
 		tfEnvs[fmt.Sprintf("TF_VAR_%s_token", config.GitProvider)] = cGitUser
+		tfEnvs[fmt.Sprintf("TF_VAR_%s_user", config.GitProvider)] = cGitUser
 		tfEnvs["TF_VAR_vault_addr"] = k3d.VaultPortForwardURL
 		tfEnvs["TF_VAR_b64_docker_auth"] = base64DockerAuth
 		tfEnvs["TF_VAR_vault_token"] = vaultRootToken

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -708,68 +708,36 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		}
 
 		//Push to remotes and use https
-		if strings.Contains(viper.GetString("flags.git-protocol"), "https") {
-			// Push gitops repo to remote
-			err = gitopsRepo.Push(
-				&git.PushOptions{
-					RemoteName: config.GitProvider,
-					Auth:       httpAuth,
-				},
-			)
-			if err != nil {
-				msg := fmt.Sprintf("error pushing detokenized gitops repository to remote %s: %s", config.DestinationGitopsRepoHttpsURL, err)
-				telemetryShim.Transmit(useTelemetryFlag, segmentClient, segment.MetricGitopsRepoPushFailed, msg)
-				if !strings.Contains(msg, "already up-to-date") {
-					log.Panic().Msg(msg)
-				}
+		// Push gitops repo to remote
+		err = gitopsRepo.Push(
+			&git.PushOptions{
+				RemoteName: config.GitProvider,
+				Auth:       httpAuth,
+			},
+		)
+		if err != nil {
+			msg := fmt.Sprintf("error pushing detokenized gitops repository to remote %s: %s", config.DestinationGitopsRepoHttpsURL, err)
+			telemetryShim.Transmit(useTelemetryFlag, segmentClient, segment.MetricGitopsRepoPushFailed, msg)
+			if !strings.Contains(msg, "already up-to-date") {
+				log.Panic().Msg(msg)
 			}
-
-			// push metaphor repo to remote
-			err = metaphorRepo.Push(
-				&git.PushOptions{
-					RemoteName: "origin",
-					Auth:       httpAuth,
-				},
-			)
-			if err != nil {
-				msg := fmt.Sprintf("error pushing detokenized metaphor repository to remote %s: %s", config.DestinationMetaphorRepoGitURL, err)
-				telemetryShim.Transmit(useTelemetryFlag, segmentClient, segment.MetricGitopsRepoPushFailed, msg)
-				if !strings.Contains(msg, "already up-to-date") {
-					log.Panic().Msg(msg)
-				}
-			}
-			log.Info().Msgf("successfully pushed gitops and metaphor repositories to https://%s/%s", cGitHost, cGitOwner)
-		} else { //default to ssh
-			err = gitopsRepo.Push(
-				&git.PushOptions{
-					RemoteName: config.GitProvider,
-					Auth:       publicKeys,
-				},
-			)
-			if err != nil {
-				msg := fmt.Sprintf("error pushing detokenized gitops repository to remote %s: %s", config.DestinationGitopsRepoGitURL, err)
-				telemetryShim.Transmit(useTelemetryFlag, segmentClient, segment.MetricGitopsRepoPushFailed, msg)
-				if !strings.Contains(msg, "already up-to-date") {
-					log.Panic().Msg(msg)
-				}
-			}
-
-			// push metaphor repo to remote
-			err = metaphorRepo.Push(
-				&git.PushOptions{
-					RemoteName: "origin",
-					Auth:       publicKeys,
-				},
-			)
-			if err != nil {
-				msg := fmt.Sprintf("error pushing detokenized metaphor repository to remote %s: %s", config.DestinationMetaphorRepoGitURL, err)
-				telemetryShim.Transmit(useTelemetryFlag, segmentClient, segment.MetricGitopsRepoPushFailed, msg)
-				if !strings.Contains(msg, "already up-to-date") {
-					log.Panic().Msg(msg)
-				}
-			}
-			log.Info().Msgf("successfully pushed gitops and metaphor repositories to git@%s/%s", cGitHost, cGitOwner)
 		}
+
+		// push metaphor repo to remote
+		err = metaphorRepo.Push(
+			&git.PushOptions{
+				RemoteName: "origin",
+				Auth:       httpAuth,
+			},
+		)
+		if err != nil {
+			msg := fmt.Sprintf("error pushing detokenized metaphor repository to remote %s: %s", config.DestinationMetaphorRepoGitURL, err)
+			telemetryShim.Transmit(useTelemetryFlag, segmentClient, segment.MetricGitopsRepoPushFailed, msg)
+			if !strings.Contains(msg, "already up-to-date") {
+				log.Panic().Msg(msg)
+			}
+		}
+		log.Info().Msgf("successfully pushed gitops and metaphor repositories to https://%s/%s", cGitHost, cGitOwner)
 
 		// todo delete the local gitops repo and re-clone it
 		// todo that way we can stop worrying about which origin we're going to push to

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -492,6 +492,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		KubeconfigPath:                config.Kubeconfig,
 		GitopsRepoGitURL:              config.DestinationGitopsRepoGitURL,
 		GitopsRepoHttpsURL:            config.DestinationGitopsRepoHttpsURL,
+		GitopsRepoURL:                 config.DestinationGitopsRepoURL,
 		GitProvider:                   config.GitProvider,
 		ClusterId:                     clusterId,
 		CloudProvider:                 k3d.CloudProvider,
@@ -792,19 +793,10 @@ func runK3d(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		DestinationGitopsRepoURL := ""
-
-		if strings.Contains(viper.GetString("git-protocol"), "https") {
-			DestinationGitopsRepoURL = config.DestinationGitopsRepoHttpsURL
-
-		} else {
-			DestinationGitopsRepoURL = config.DestinationGitopsRepoGitURL
-		}
-
 		err = k3d.AddK3DSecrets(
 			atlantisWebhookSecret,
 			viper.GetString("kbot.public-key"),
-			DestinationGitopsRepoURL,
+			config.DestinationGitopsRepoURL,
 			viper.GetString("kbot.private-key"),
 			config.GitProvider,
 			cGitUser,
@@ -1036,7 +1028,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		}
 
 		log.Info().Msg("applying the registry application to argocd")
-		registryApplicationObject := argocd.GetArgoCDApplicationObject(config.DestinationGitopsRepoHttpsURL, fmt.Sprintf("registry/%s", clusterNameFlag))
+		registryApplicationObject := argocd.GetArgoCDApplicationObject(config.DestinationGitopsRepoURL, fmt.Sprintf("registry/%s", clusterNameFlag))
 		_, _ = argocdClient.ArgoprojV1alpha1().Applications("argocd").Create(context.Background(), registryApplicationObject, metav1.CreateOptions{})
 		viper.Set("kubefirst-checks.argocd-create-registry", true)
 		viper.WriteConfig()

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -138,6 +138,11 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("only one of --github-user or --github-org can be supplied")
 	}
 
+	//Validate we got a branch if they gave us a repo
+	if gitopsTemplateURLFlag != "" && gitopsTemplateBranchFlag == "" {
+		log.Panic().Msgf("must supply gitops-template-branch flag when gitops-template-url is set")
+	}
+
 	// Check for existing port forwards before continuing
 	err = k8s.CheckForExistingPortForwards(8080, 8200, 9000, 9094)
 	if err != nil {

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -732,7 +732,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 			},
 		)
 		if err != nil {
-			msg := fmt.Sprintf("error pushing detokenized metaphor repository to remote %s: %s", config.DestinationMetaphorRepoGitURL, err)
+			msg := fmt.Sprintf("error pushing detokenized metaphor repository to remote %s: %s", config.DestinationMetaphorRepoHttpsURL, err)
 			telemetryShim.Transmit(useTelemetryFlag, segmentClient, segment.MetricGitopsRepoPushFailed, msg)
 			if !strings.Contains(msg, "already up-to-date") {
 				log.Panic().Msg(msg)

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -1214,7 +1214,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 		log.Info().Msg("configuring vault with terraform")
 
 		tfEnvs["TF_VAR_email_address"] = "your@email.com"
-		tfEnvs[fmt.Sprintf("TF_VAR_%s_token", config.GitProvider)] = cGitUser
+		tfEnvs[fmt.Sprintf("TF_VAR_%s_token", config.GitProvider)] = cGitToken
 		tfEnvs[fmt.Sprintf("TF_VAR_%s_user", config.GitProvider)] = cGitUser
 		tfEnvs["TF_VAR_vault_addr"] = k3d.VaultPortForwardURL
 		tfEnvs["TF_VAR_b64_docker_auth"] = base64DockerAuth

--- a/cmd/k3d/create.go
+++ b/cmd/k3d/create.go
@@ -1215,6 +1215,7 @@ func runK3d(cmd *cobra.Command, args []string) error {
 
 		tfEnvs["TF_VAR_email_address"] = "your@email.com"
 		tfEnvs[fmt.Sprintf("TF_VAR_%s_token", config.GitProvider)] = cGitToken
+		tfEnvs[fmt.Sprintf("TF_VAR_%s_token", config.GitProvider)] = cGitUser
 		tfEnvs["TF_VAR_vault_addr"] = k3d.VaultPortForwardURL
 		tfEnvs["TF_VAR_b64_docker_auth"] = base64DockerAuth
 		tfEnvs["TF_VAR_vault_token"] = vaultRootToken


### PR DESCRIPTION
Best approach I could come up with for adding https only support while retaining the most critical ssh functionality without a ton of bloat and following existing patterns. Open to changing pretty much anything. I wouldn't consider this a breaking change, because the cli should default to ssh if the flag isn't provided 

This PR relies on 
GitOps-Template PR: https://github.com/kubefirst/gitops-template/pull/498
Runtime PR: https://github.com/kubefirst/runtime/pull/51

https://github.com/kubefirst/kubefirst/issues/1566