### PR TITLE
feat: use latest api chart

### DIFF
--- a/internal/launch/cmd.go
+++ b/internal/launch/cmd.go
@@ -357,8 +357,6 @@ func Up(additionalHelmFlags []string) {
 			"--namespace",
 			namespace,
 			helmChartName,
-			"--version",
-			helmChartVersion,
 			"kubefirst/kubefirst",
 			"--set",
 			"console.ingress.createTraefikRoute=true",

--- a/internal/launch/constants.go
+++ b/internal/launch/constants.go
@@ -11,7 +11,6 @@ const (
 	helmChartName     = "kubefirst"
 	helmChartRepoName = "kubefirst"
 	helmChartRepoURL  = "https://charts.kubefirst.com"
-	helmChartVersion  = "2.2.7"
 	namespace         = "kubefirst"
 	secretName        = "kubefirst-initial-secrets"
 )


### PR DESCRIPTION
`kubefirst launch up --helm-flag "--version v2.2.2"`  will allow users to deploy a different version