### PR TITLE
fix: add container registry url into gitops tokens

### DIFF
--- a/cmd/gcp/create.go
+++ b/cmd/gcp/create.go
@@ -362,6 +362,8 @@ func createGCP(cmd *cobra.Command, args []string) error {
 		GitopsRepoAtlantisWebhookURL: fmt.Sprintf("https://atlantis.%s/events", domainNameFlag),
 		GitopsRepoNoHTTPSURL:         fmt.Sprintf("%s.com/%s/gitops.git", cGitHost, cGitOwner),
 		ClusterId:                    clusterId,
+
+		ContainerRegistryURL: fmt.Sprintf("%s/%s/metaphor", containerRegistryHost, cGitOwner),
 	}
 
 	viper.Set(fmt.Sprintf("%s.atlantis.webhook.url", config.GitProvider), fmt.Sprintf("https://atlantis.%s/events", domainNameFlag))


### PR DESCRIPTION
![image](https://github.com/kubefirst/kubefirst/assets/6446939/93f97531-a718-4bed-8d89-be743fb8d040)
The token was previously blank and is now populated. This will resolve the error with not being able to publish metaphor to git container registries. 