### PR TITLE
fix: `ContainerRegistryURL` to template `<CONTAINER_REGISTRY_URL>` in association with `-p containerRegistryURL` usage

### DIFF
--- a/cmd/gcp/create.go
+++ b/cmd/gcp/create.go
@@ -386,7 +386,7 @@ func createGCP(cmd *cobra.Command, args []string) error {
 		GitopsRepoNoHTTPSURL:         fmt.Sprintf("%s.com/%s/gitops.git", cGitHost, cGitOwner),
 		ClusterId:                    clusterId,
 
-		ContainerRegistryURL: fmt.Sprintf("%s/%s/metaphor", containerRegistryHost, cGitOwner),
+		ContainerRegistryURL: fmt.Sprintf("%s/%s", containerRegistryHost, cGitOwner),
 	}
 
 	viper.Set(fmt.Sprintf("%s.atlantis.webhook.url", config.GitProvider), fmt.Sprintf("https://atlantis.%s/events", domainNameFlag))
@@ -668,7 +668,7 @@ func createGCP(cmd *cobra.Command, args []string) error {
 	metaphorDirectoryTokens := providerConfigs.MetaphorTokenValues{
 		ClusterName:                   clusterNameFlag,
 		CloudRegion:                   cloudRegionFlag,
-		ContainerRegistryURL:          fmt.Sprintf("%s/%s/metaphor", containerRegistryHost, cGitOwner),
+		ContainerRegistryURL:          fmt.Sprintf("%s/%s", containerRegistryHost, cGitOwner),
 		DomainName:                    domainNameFlag,
 		MetaphorDevelopmentIngressURL: fmt.Sprintf("metaphor-development.%s", domainNameFlag),
 		MetaphorStagingIngressURL:     fmt.Sprintf("metaphor-staging.%s", domainNameFlag),

--- a/cmd/gcp/create.go
+++ b/cmd/gcp/create.go
@@ -88,7 +88,7 @@ func createGCP(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	forceDestroy, err := cmd.Flags().GetBool("force_destroy")
+	forceDestroy, err := cmd.Flags().GetBool("force-destroy")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is an example fix for a problem involving the composition of FQINs for the metaphor image from subcomponents. 

It has been tested with GKE + ghcr in particular, but may break [other instances where `<CONTAINER_REGISTRY_URL>`](https://github.com/search?q=repo%3Akubefirst%2Fgitops-template%20%22%3CCONTAINER_REGISTRY_URL%3E%22&type=code) is used.

It might also be reasonable to consider something like https://github.com/kubefirst/gitops-template/pull/549 if the pattern `platform-registry` analogous to `gcp-github` would also attempt to account for `aws-ecr` and `gcp-gar` as appears to currently be the case for `aws-github`.

---

Given a FQIN for a ghcr-hosted container image constructed of subcomponents

| URL      | ghorg       | repo       |   | tag    |
|----------|-------------|------------|---|--------|
| ghcr.io  | kubefirst   | metaphor   | : | 8aea8  |

we could define `CONTAINER_REGISTRY_URL=URL/ghorg` among any other reasonable composition of subcomponents into composite variables so long as they are used consistently.

`ContainerRegistryURL` [needs to be defined](https://github.com/kubefirst/kubefirst/pull/1774/files#diff-6040cc8f123eb23769199fdb2bf7d705eedaa3d4d3175306cf0470da3a393565L389) such that it [generates](https://github.com/kubefirst/runtime/blob/16b85456b7a2ede4fe3795a466ce205164765029/pkg/providerConfigs/detokenize.go#L233) the correct value in [gitops-template/gcp-github/ci/.github/workflows/main.yaml#L5](https://github.com/kubefirst/gitops-template/blob/e2adb967ddf5427055665f3deaaf8a08d4295f4c/gcp-github/ci/.github/workflows/main.yaml#L5) relative to it's usage in [gitops-template/gcp-github/ci/.github/workflows/main.yaml#L53](https://github.com/kubefirst/gitops-template/blob/e2adb967ddf5427055665f3deaaf8a08d4295f4c/gcp-github/ci/.github/workflows/main.yaml#L53). There are analogs to this for the other `provider-registry` combinations, but gcp and aws are special cases as there's an attempt to support their respective internal registries in addition to the associated git providers. This may need to be revisited in the near future, but `CONTAINER_REGISTRY_URL=URL/ghorg` may work well enough for now.