### PR TITLE
fix: aws containerRegistryURL metaphor duplication

### DIFF
--- a/cmd/aws/create.go
+++ b/cmd/aws/create.go
@@ -608,7 +608,7 @@ func createAws(cmd *cobra.Command, args []string) error {
 	if ecrFlag {
 		containerRegistryURL = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", awsAccountID, cloudRegionFlag)
 	} else {
-		containerRegistryURL = fmt.Sprintf("%s/%s/metaphor", containerRegistryHost, cGitOwner)
+		containerRegistryURL = fmt.Sprintf("%s/%s", containerRegistryHost, cGitOwner)
 	}
 
 	var externalDNSProviderTokenEnvName, externalDNSProviderSecretKey string


### PR DESCRIPTION
This PR replicates #1774, which was gcp-only, for aws based on the reports by @alechp .