### PR TITLE
ci: don't include PR number is commit linting lenght for titles

### DIFF
--- a/.commitlint.json
+++ b/.commitlint.json
@@ -1,6 +1,0 @@
-{
-    "parserPreset": "conventional-changelog-conventionalcommits",
-	"rules": {
-        "header-max-length": [2, "always", 72]
-    }
-}

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,8 +1,6 @@
 const rules = require('@commitlint/rules');
 
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  parserPreset: 'conventional-changelog-conventionalcommits',
   rules: {
     'header-max-length': [2, 'always', 72],
   },

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,0 +1,19 @@
+const rules = require('@commitlint/rules');
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  parserPreset: 'conventional-changelog-conventionalcommits',
+  rules: {
+    'header-max-length': [2, 'always', 72],
+  },
+  plugins: [
+    {
+      rules: {
+        'header-max-length': (parsed, _when, _value) => {
+          parsed.header = parsed.header.replace(/\s\(#[0-9]+\)$/, '')
+          return rules.default['header-max-length'](parsed, _when, _value)
+        },
+      },
+    },
+  ]
+}

--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -7,12 +7,12 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@main
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
       
       - name: Lint the commits
-        uses: wagoid/commitlint-github-action@v5
+        uses: wagoid/commitlint-github-action@v5.4.3
         with:
-          configFile: .commitlint.json
+          configFile: .commitlintrc.js
           failOnWarnings: true


### PR DESCRIPTION
This will fix the annoying GitHub Action failure after a PR is merged