### PR TITLE
chore: add a field for the OS for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -61,6 +61,18 @@ body:
         - GitLab
     validations:
       required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Which Operating System?
+      description: Please add the architecture in the issue description. If you selected "Others", please specify in the textarea.
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
   - type: textarea
     id: issue
     attributes:


### PR DESCRIPTION
We are starting to have more OS specific issues, this will save us time to have the information right away.