### PR TITLE
chore: add a 'none specific option for OS'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -68,6 +68,7 @@ body:
       label: Which Operating System?
       description: Please add the architecture in the issue description. If you selected "Others", please specify in the textarea.
       options:
+        - None specific
         - macOS
         - Linux
         - Windows


### PR DESCRIPTION
Useful when the issue is happening inside kubefirst, and not on the user's computer.