### PR TITLE
add node type and node count flags to aws, civo, google, and vultr

### DIFF
--- a/cmd/aws/command.go
+++ b/cmd/aws/command.go
@@ -9,6 +9,7 @@ package aws
 import (
 	"fmt"
 
+	"github.com/kubefirst/kubefirst-api/pkg/constants"
 	"github.com/kubefirst/kubefirst/internal/common"
 	"github.com/kubefirst/kubefirst/internal/progress"
 	"github.com/spf13/cobra"
@@ -31,6 +32,8 @@ var (
 	domainNameFlag           string
 	useTelemetryFlag         bool
 	ecrFlag                  bool
+	nodeTypeFlag             string
+	nodeCountFlag            string
 
 	// RootCredentials
 	copyArgoCDPasswordToClipboardFlag bool
@@ -73,6 +76,8 @@ func Create() *cobra.Command {
 		// PreRun:           common.CheckDocker,
 	}
 
+	awsDefaults := constants.GetCloudDefaults().Aws
+
 	// todo review defaults and update descriptions
 	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
@@ -80,6 +85,8 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "us-east-1", "the aws region to provision infrastructure in")
 	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
 	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", awsDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", awsDefaults.InstanceSize, "the instance size of the cluster to create")
 	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "aws", fmt.Sprintf("the dns provider - one of: %s", supportedDNSProviders))
 	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the Route53/Cloudflare hosted zone name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")

--- a/cmd/civo/command.go
+++ b/cmd/civo/command.go
@@ -9,6 +9,7 @@ package civo
 import (
 	"fmt"
 
+	"github.com/kubefirst/kubefirst-api/pkg/constants"
 	"github.com/kubefirst/kubefirst/internal/common"
 	"github.com/kubefirst/kubefirst/internal/progress"
 	"github.com/spf13/cobra"
@@ -30,6 +31,8 @@ var (
 	gitopsTemplateURLFlag    string
 	gitopsTemplateBranchFlag string
 	useTelemetryFlag         bool
+	nodeTypeFlag             string
+	nodeCountFlag            string
 
 	// RootCredentials
 	copyArgoCDPasswordToClipboardFlag bool
@@ -84,6 +87,8 @@ func Create() *cobra.Command {
 		// PreRun:           common.CheckDocker,
 	}
 
+	civoDefaults := constants.GetCloudDefaults().Civo
+
 	// todo review defaults and update descriptions
 	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
@@ -91,6 +96,8 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "NYC1", "the civo region to provision infrastructure in")
 	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
 	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", civoDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", civoDefaults.InstanceSize, "the instance size of the cluster to create")
 	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "civo", fmt.Sprintf("the dns provider - one of: %s", supportedDNSProviders))
 	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the Civo DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")

--- a/cmd/google/command.go
+++ b/cmd/google/command.go
@@ -9,6 +9,7 @@ package google
 import (
 	"fmt"
 
+	"github.com/kubefirst/kubefirst-api/pkg/constants"
 	"github.com/kubefirst/kubefirst/internal/common"
 	"github.com/kubefirst/kubefirst/internal/progress"
 	"github.com/spf13/cobra"
@@ -32,6 +33,8 @@ var (
 	gitopsTemplateBranchFlag string
 	useTelemetryFlag         bool
 	forceDestroyFlag         bool
+	nodeTypeFlag             string
+	nodeCountFlag            string
 
 	// RootCredentials
 	copyArgoCDPasswordToClipboardFlag bool
@@ -79,6 +82,8 @@ func Create() *cobra.Command {
 		// PreRun:           common.CheckDocker,
 	}
 
+	googleDefaults := constants.GetCloudDefaults().Google
+
 	// todo review defaults and update descriptions
 	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
@@ -86,6 +91,8 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "us-east1", "the GCP region to provision infrastructure in")
 	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
 	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", googleDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", googleDefaults.InstanceSize, "the instance size of the cluster to create")
 	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "google", fmt.Sprintf("the dns provider - one of: %s", supportedDNSProviders))
 	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the GCP DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")

--- a/cmd/vultr/command.go
+++ b/cmd/vultr/command.go
@@ -9,6 +9,7 @@ package vultr
 import (
 	"fmt"
 
+	"github.com/kubefirst/kubefirst-api/pkg/constants"
 	"github.com/kubefirst/kubefirst/internal/common"
 	"github.com/kubefirst/kubefirst/internal/progress"
 	"github.com/spf13/cobra"
@@ -30,6 +31,8 @@ var (
 	gitopsTemplateURLFlag    string
 	gitopsTemplateBranchFlag string
 	useTelemetryFlag         bool
+	nodeTypeFlag             string
+	nodeCountFlag            string
 
 	// RootCredentials
 	copyArgoCDPasswordToClipboardFlag bool
@@ -77,6 +80,8 @@ func Create() *cobra.Command {
 		// PreRun:           common.CheckDocker,
 	}
 
+	vultrDefaults := constants.GetCloudDefaults().Vultr
+
 	// todo review defaults and update descriptions
 	createCmd.Flags().StringVar(&alertsEmailFlag, "alerts-email", "", "email address for let's encrypt certificate notifications (required)")
 	createCmd.MarkFlagRequired("alerts-email")
@@ -84,6 +89,8 @@ func Create() *cobra.Command {
 	createCmd.Flags().StringVar(&cloudRegionFlag, "cloud-region", "ewr", "the Vultr region to provision infrastructure in")
 	createCmd.Flags().StringVar(&clusterNameFlag, "cluster-name", "kubefirst", "the name of the cluster to create")
 	createCmd.Flags().StringVar(&clusterTypeFlag, "cluster-type", "mgmt", "the type of cluster to create (i.e. mgmt|workload)")
+	createCmd.Flags().StringVar(&nodeCountFlag, "node-count", vultrDefaults.NodeCount, "the node count for the cluster")
+	createCmd.Flags().StringVar(&nodeTypeFlag, "node-type", vultrDefaults.InstanceSize, "the instance size of the cluster to create")
 	createCmd.Flags().StringVar(&dnsProviderFlag, "dns-provider", "vultr", fmt.Sprintf("the dns provider - one of: %s", supportedDNSProviders))
 	createCmd.Flags().StringVar(&domainNameFlag, "domain-name", "", "the Vultr DNS Name to use for DNS records (i.e. your-domain.com|subdomain.your-domain.com) (required)")
 	createCmd.MarkFlagRequired("domain-name")


### PR DESCRIPTION
somehow didn't push this with the last PR
