### PR TITLE
chore: make installation type for marketplace generic for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -46,9 +46,9 @@ body:
       multiple: true
       options:
         - None specific
-        - UI (Console app)
         - CLI
-        - Civo Marketplace
+        - Marketplace
+        - UI (Console app)
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
We can know which marketplace it is from the selected cloud.