### PR TITLE
2.4.4 - adoption of talos distro on civo github and civo gitlab management clusters

### DIFF
--- a/internal/launch/constants.go
+++ b/internal/launch/constants.go
@@ -11,7 +11,7 @@ const (
 	helmChartName     = "kubefirst"
 	helmChartRepoName = "kubefirst"
 	helmChartRepoURL  = "https://charts.kubefirst.com"
-	helmChartVersion  = "2.4.3"
+	helmChartVersion  = "2.4.4"
 	namespace         = "kubefirst"
 	secretName        = "kubefirst-initial-secrets"
 )

--- a/internal/launch/constants.go
+++ b/internal/launch/constants.go
@@ -11,7 +11,7 @@ const (
 	helmChartName     = "kubefirst"
 	helmChartRepoName = "kubefirst"
 	helmChartRepoURL  = "https://charts.kubefirst.com"
-	helmChartVersion  = "2.4.1"
+	helmChartVersion  = "2.4.2-rc1"
 	namespace         = "kubefirst"
 	secretName        = "kubefirst-initial-secrets"
 )


### PR DESCRIPTION
2.4.4 introduced rootless and privledged-free talos distribution to the kubefirst management cluster on github and gitlab versions of civo cloud provisions.